### PR TITLE
Update to 0.8 beta

### DIFF
--- a/sodrtd/dialogues/add_additional_infopoints.d
+++ b/sodrtd/dialogues/add_additional_infopoints.d
@@ -80,11 +80,11 @@ BEGIN C#RtDpct
 CHAIN
 IF ~Global("C#RtD_CrusaderBlessingQuest","GLOBAL",3)~ THEN C#RtDpct detect_blessing
 @1014 /* [PC Selftalk](You witnessed a "blessing ritual" of one of Caelar's priests.) */
-== BDGLINTJ IF ~IsValidForPartyDialogue("GLINT") Class("GLINT",CLERIC_ALL)~ THEN @1015 /* [Glint]Nah, how can he say it was granted by "the gods"... blasphemy is what that was, nothing more. */
-== BDVICONJ IF ~IsValidForPartyDialogue("VICONIA") Class("VICONIA",CLERIC_ALL)~ THEN @1016 /* [Viconia]This blessing from "the gods" might have been good for the morale of Caelar's followers, but that was all there is to it. */
 == C#RtDpct IF ~OR(2)
 Class(Player1,CLERIC_ALL)
-Class(Player1,PALADIN_ALL)~ THEN @1017 /* [PC Selftalk](You didn't need anyone else's observation to determine that this "blessing" is nothing special at all, and definitely not a protection by "the gods" as proclaimed by the priest performing the ritual.) */
+Class(Player1,PALADIN_ALL)
+OR(2) !IsValidForPartyDialogue("GLINT") !Class("GLINT",CLERIC_ALL)
+OR(2) !IsValidForPartyDialogue("VICONIA") !Class("VICONIA",CLERIC_ALL)~ THEN @1017 /* [PC Selftalk](You didn't need anyone else's observation to determine that this "blessing" is nothing special at all, and definitely not a protection by "the gods" as proclaimed by the priest performing the ritual.) */
 END
 IF ~~ THEN DO ~SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",4) 
 SetGlobal("C#RtD_CaelarProtection_SET","GLOBAL",4)
@@ -129,6 +129,26 @@ Class(Player6,PALADIN_ALL)
 !Name("VICONIA",Player6)
 !Class(Player1,CLERIC_ALL)
 !Class(Player1,PALADIN_ALL)~ THEN + player6
+IF ~IsValidForPartyDialogue("GLINT") Class("GLINT",CLERIC_ALL)~ THEN EXTERN BDGLINTJ glint_noticed
+IF ~IsValidForPartyDialogue("VICONIA") Class("VICONIA",CLERIC_ALL)~ THEN EXTERN BDVICONJ viconia_noticed
+
+APPEND BDGLINTJ
+IF ~~ THEN glint_noticed
+SAY @1015 /* [Glint]Nah, how can he say it was granted by "the gods"... blasphemy is what that was, nothing more. */
+IF ~~ THEN DO ~SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",4) 
+SetGlobal("C#RtD_CaelarProtection_SET","GLOBAL",4)
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)EraseJournalEntry(@32) EraseJournalEntry(@33) AddJournalEntry(@35,QUEST_DONE)~ EXIT
+END
+END
+
+APPEND BDVICONJ 
+IF ~~ THEN viconia_noticed
+SAY @1016 /* [Viconia]This blessing from "the gods" might have been good for the morale of Caelar's followers, but that was all there is to it. */
+IF ~~ THEN DO ~SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",4) 
+SetGlobal("C#RtD_CaelarProtection_SET","GLOBAL",4)
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)EraseJournalEntry(@32) EraseJournalEntry(@33) AddJournalEntry(@35,QUEST_DONE)~ EXIT
+END
+END
 
 APPEND C#RtDpct 
 

--- a/sodrtd/dialogues/add_inform_officers_basic.d
+++ b/sodrtd/dialogues/add_inform_officers_basic.d
@@ -334,7 +334,8 @@ SAY @3 /* Do you have anything else you want to share? */
 Global("C#RtD_bddelanc_to_4","GLOBAL",0)~ + @1 /* I have no more information to share right now. */ + intermediate_4
 + ~GlobalGT("bd_plot","global",304)
 GlobalLT("bd_plot","global",350)
-AreaCheck("bd3000")~ + @1 /* I have no more information to share right now. */ + 31
+AreaCheck("bd3000")
+!Global("C#RtD_bddelanc_to_4","GLOBAL",1)~ + @1 /* I have no more information to share right now. */ + 31
 + ~OR(2)
 Global("bd_plot","global",392)
 Global("bd_plot","global",393)

--- a/sodrtd/dialogues/add_reactions.d
+++ b/sodrtd/dialogues/add_reactions.d
@@ -146,7 +146,7 @@ GlobalGT("C#RtD_CoalCaelarKidnap","GLOBAL",0)~ THEN @1516 /* [Torsin De Lancie]T
 == bddelanc IF ~OR(2)
 Global("C#RtD_CoalKnowsPortalBlood","GLOBAL",3)
 Global("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)~ THEN @1518 /* [Torsin De Lancie]This is important news, as it clears Caelar's motivation with regard to you, <CHARNAME>. It is evident she needs your blood to open the portal to Avernus beneath Dragonspear Castle! */ DO ~SetGlobal("C#RtD_CoalKnowsPortalBlood","GLOBAL",6)~ 
-== bdnederl IF ~GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",2)~ THEN @1519 /* [Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking crusade - this is about preventing a second fiend war! */
+== bdnederl IF ~GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",2)~ THEN @1519 /* [Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking crusade - this is about preventing a third fiend war! */
 
 /* know about Bhaal blood needed to open portal */
 /* they have maximum knowledge about the portal, will get general follow up after bdnederl 28 */
@@ -329,7 +329,7 @@ END //APPEND
 CHAIN
 IF WEIGHT #-1
 ~AreaCheck("c#rtd1")~ THEN bdnederl update_delancie_gather_officers_02
-@1519 /* [Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking crusade - this is about preventing a second fiend war! */
+@1519 /* [Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking crusade - this is about preventing a third fiend war! */
 == bddelanc @1554 /* [Torsin De Lancie]It is evident she needs your blood to open the portal to Avernus beneath Dragonspear Castle! It is imperative for Caelar's crusade to get to <CHARNAME> - alive. And this leaves us with a glaring problem having you here, <CHARNAME>! */
 END
 IF ~~ THEN EXTERN bddelanc hysterics 

--- a/sodrtd/dialogues/add_sir_deggernaut_temp.d
+++ b/sodrtd/dialogues/add_sir_deggernaut_temp.d
@@ -91,12 +91,8 @@ GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",2)~ + @222 /* It seems the crusaders wa
 GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",4)~ + @208 /* You are aware that Caelar *will* march her crusade into Avernus, though? */ DO ~%Set_CheckCaelarPlan_4_OR_5% SetGlobal("C#RtD_CoalCaelarPlan","GLOBAL",4) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_01
 /* if PC knows that Caelar is planning on marching into Avernus AND Hephernaan is working for a fiend, they can speculate that they are planning on opening a portal to Avernus */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2)
-	Global("C#RtD_CaelarPlan","GLOBAL",2)
-	Global("C#RtD_CaelarPlan","GLOBAL",3)
-OR(2)
-	GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
-	GlobalGT("C#RtD_KnowsPortalBlood","GLOBAL",0)
++ ~Global("C#RtD_CaelarPlan","GLOBAL",3)
+GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_KnowsPortalBlood","GLOBAL",0) //so reply options will not be doubled
 !Global("C#RtD_CoalCaelarPlan","GLOBAL",6)~ + @278 /* I have reasons to believe that Caelar is planning on opening a portal to Avernus to march her army into it. */ DO ~%Set_CheckCaelarPlan_6_OR_7%
 SetGlobal("C#RtD_CaelarPlan","GLOBAL",4) //no _SET
@@ -184,16 +180,17 @@ Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to b
 Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
+//## !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)
 + ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
 	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
 GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @211 /* I have disturbing news. Caelar's advisor Hephernaan is apparently working for a fiend who is planning on crossing into the Material Prime! */ DO ~%Set_CheckHephernaanFiend_GT_0%
+!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~%Set_CheckHephernaanFiend_GT_0%
 %Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2%
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
 //	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
 //	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend_SET","GLOBAL",1) 
+	SetGlobal("C#RtD_CoalHephernaanFiend","GLOBAL",1) 
 //	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
 //	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
 	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_04

--- a/sodrtd/readme.sodrtd.French.txt
+++ b/sodrtd/readme.sodrtd.French.txt
@@ -450,6 +450,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 HISTORY
 
+Version 0.8 Beta
+- Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.
+- Dialogue with officers in bd3000.are should not skip parts if PC has nothing to report, and thre should be no doubled reply options.
+- Viconia's or Glint's interjection into PC's self-talk about crusader camp "blessing" should not break the dialogue.
+- Marshal Nederlok should be aware there were already two fiend wars at Dragonspear Castle.
+- Sir Deggernaut's dialogue should not double reply options.
+- Optimized variable triggers for PC's conclusions regarding Caelar's plans.
+
 Version 0.7 Beta
 - added Italian version by improb@bile
 - refined variable triggers for conclusion that Caelar is no child of Bhaal.

--- a/sodrtd/readme.sodrtd.english.txt
+++ b/sodrtd/readme.sodrtd.english.txt
@@ -447,6 +447,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 HISTORY
 
+Version 0.8 Beta
+- Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.
+- Dialogue with officers in bd3000.are should not skip parts if PC has nothing to report, and thre should be no doubled reply options.
+- Viconia's or Glint's interjection into PC's self-talk about crusader camp "blessing" should not break the dialogue.
+- Marshal Nederlok should be aware there were already two fiend wars at Dragonspear Castle.
+- Sir Deggernaut's dialogue should not double reply options.
+- Optimized variable triggers for PC's conclusions regarding Caelar's plans.
+
 Version 0.7 Beta
 - added Italian version by improb@bile 
 - refined variable triggers for conclusion that Caelar is no child of Bhaal.

--- a/sodrtd/readme.sodrtd.german.txt
+++ b/sodrtd/readme.sodrtd.german.txt
@@ -447,6 +447,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 ÄNDERUNGSHISTORIE
 
+Version 0.8 Beta
+- Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.
+- Dialogue with officers in bd3000.are should not skip parts if PC has nothing to report, and thre should be no doubled reply options.
+- Viconia's or Glint's interjection into PC's self-talk about crusader camp "blessing" should not break the dialogue.
+- Marshal Nederlok should be aware there were already two fiend wars at Dragonspear Castle.
+- Sir Deggernaut's dialogue should not double reply options.
+- Optimized variable triggers for PC's conclusions regarding Caelar's plans.
+
 Version 0.7 Beta
 - added Italian version by improb@bile
 - refined variable triggers for conclusion that Caelar is no child of Bhaal.

--- a/sodrtd/scripts/additional_infopoints_bd2000.baf
+++ b/sodrtd/scripts/additional_infopoints_bd2000.baf
@@ -56,26 +56,62 @@ IF
 	Global("C#RtD_CaelarProtection","GLOBAL",3)
 	GlobalGT("C#RtD_CrusaderBlessingQuest","GLOBAL",0)
 	GlobalLT("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
-	!Class(Player1,PALADIN_ALL)
-	!Class(Player1,CLERIC_ALL)
-	OR(10)
+	OR(2)
 		Class(Player2,PALADIN_ALL)
-		Class(Player3,PALADIN_ALL)
-		Class(Player4,PALADIN_ALL)
-		Class(Player5,PALADIN_ALL)
-		Class(Player6,PALADIN_ALL)
 		Class(Player2,CLERIC_ALL)
+	IsValidForPartyDialogue(Player2)
+THEN
+  RESPONSE #100
+		SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+END
+
+IF
+	Global("C#RtD_CaelarProtection","GLOBAL",3)
+	GlobalGT("C#RtD_CrusaderBlessingQuest","GLOBAL",0)
+	GlobalLT("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+	OR(2)
+		Class(Player3,PALADIN_ALL)
 		Class(Player3,CLERIC_ALL)
+	IsValidForPartyDialogue(Player3)
+THEN
+  RESPONSE #100
+		SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+END
+
+IF
+	Global("C#RtD_CaelarProtection","GLOBAL",3)
+	GlobalGT("C#RtD_CrusaderBlessingQuest","GLOBAL",0)
+	GlobalLT("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+	OR(2)
+		Class(Player4,PALADIN_ALL)
 		Class(Player4,CLERIC_ALL)
+	IsValidForPartyDialogue(Player4)
+THEN
+  RESPONSE #100
+		SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+END
+
+IF
+	Global("C#RtD_CaelarProtection","GLOBAL",3)
+	GlobalGT("C#RtD_CrusaderBlessingQuest","GLOBAL",0)
+	GlobalLT("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+	OR(2)
+		Class(Player5,PALADIN_ALL)
 		Class(Player5,CLERIC_ALL)
+	IsValidForPartyDialogue(Player5)
+THEN
+  RESPONSE #100
+		SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+END
+
+IF
+	Global("C#RtD_CaelarProtection","GLOBAL",3)
+	GlobalGT("C#RtD_CrusaderBlessingQuest","GLOBAL",0)
+	GlobalLT("C#RtD_CrusaderBlessingQuest","GLOBAL",3)
+	OR(2)
+		Class(Player6,PALADIN_ALL)
 		Class(Player6,CLERIC_ALL)
-	IsValidForPartyDialogue(Player1)
-	OR(5)
-		IsValidForPartyDialogue(Player2)
-		IsValidForPartyDialogue(Player3)
-		IsValidForPartyDialogue(Player4)
-		IsValidForPartyDialogue(Player5)
-		IsValidForPartyDialogue(Player6)
+	IsValidForPartyDialogue(Player6)
 THEN
   RESPONSE #100
 		SetGlobal("C#RtD_CrusaderBlessingQuest","GLOBAL",3)

--- a/sodrtd/sodrtd.tp2
+++ b/sodrtd/sodrtd.tp2
@@ -3,7 +3,7 @@ BACKUP ~sodrtd/backup~
 AUTHOR ~https://baldurs-gate.de/index.php?resources/road-to-discovery-for-sod.59/~ 
 
 
-VERSION ~0.7 (Beta)~
+VERSION ~0.8 (Beta)~
 
 
 README ~sodrtd/readme.sodrtd.%LANGUAGE%.txt~ ~sodrtd/readme.sodrtd.english.txt~
@@ -235,8 +235,7 @@ COMPILE EVALUATE_BUFFER ~sodrtd/dialogues/add_trans_action_general.d~ USING ~sod
 
 /* bd0060.bcs */
 /* A Historical Treatise of Dragonspear Castle bdbook11 #69147 
-~(Annotation: They could not destroy the portal, though. My research indicates it remains present, though dormant. Blood tainted by a god’s influence is required to activate its power. H requires us to secure the portal room the moment we take control of the castle.)~ 
-## should the mentioned "H" lead to any reactions? - not considered yet */
+~(Annotation: They could not destroy the portal, though. My research indicates it remains present, though dormant. Blood tainted by a god's influence is required to activate its power. H requires us to secure the portal room the moment we take control of the castle.)~ */
 <<<<<<<< ...inlined/bd0060_add.baf
 IF
 	PartyHasItem("BDBook11")

--- a/sodrtd/themedtweaks/dialogues/sod_stat_other.d
+++ b/sodrtd/themedtweaks/dialogues/sod_stat_other.d
@@ -31,6 +31,14 @@ END
 ////////////////////////////////////////////////////////////////////////////////////////
 // Have Corwin have a message from Eltan for you if you speak with her more than once //
 ////////////////////////////////////////////////////////////////////////////////////////
+EXTEND_BOTTOM BDCORWIN 4
+	IF ~Global("#L_SoDStat_DaustonTalk","GLOBAL",2)~ THEN DO ~SetGlobal("#L_BDCORWIN_TRACKER","MYAREA",4)~ GOTO MESSAGE_FOR_YOU_SIR
+END
+
+EXTEND_BOTTOM BDCORWIN 13
+	IF ~Global("#L_SoDStat_DaustonTalk","GLOBAL",2)~ THEN DO ~SetGlobal("#L_BDCORWIN_TRACKER","MYAREA",13)~ GOTO MESSAGE_FOR_YOU_SIR
+END
+
 EXTEND_BOTTOM BDCORWIN 17
 	IF ~Global("#L_SoDStat_DaustonTalk","GLOBAL",2)~ THEN DO ~SetGlobal("#L_BDCORWIN_TRACKER","MYAREA",17)~ GOTO MESSAGE_FOR_YOU_SIR
 END
@@ -118,6 +126,8 @@ APPEND BDCORWIN
 	
 	IF ~~ THEN BEGIN DAUSTON_MESSAGE_3
 		SAY @4035 /* ~Her uncle managed to get her out by sacrificing himself.  He is now a prisoner in Avernus...in her place.~ */
+		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",4)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_4
+		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",13)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_13
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",17)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_17
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",20)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_20
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",27)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_27
@@ -135,6 +145,16 @@ APPEND BDCORWIN
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",54)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_54
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",55)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_55
 		IF ~Global("#L_BDCORWIN_TRACKER","MYAREA",56)~ THEN REPLY @4036 /* ~How awful.  But that does explain a lot.~ */ DO ~SetGlobal("#L_SoDStat_DaustonTalk","GLOBAL",3)~ SOLVED_JOURNAL @3004 + DAUSTON_MESSAGE_4_56
+	END
+	
+	IF ~~ THEN BEGIN DAUSTON_MESSAGE_4_4
+		SAY #%eet_2%42104 /* ~All right then.~ */
+		COPY_TRANS BDCORWIN 4
+	END
+	
+	IF ~~ THEN BEGIN DAUSTON_MESSAGE_4_13
+		SAY #%eet_2%42104 /* ~All right then.~ */
+		COPY_TRANS BDCORWIN 13
 	END
 	
 	IF ~~ THEN BEGIN DAUSTON_MESSAGE_4_17
@@ -227,6 +247,8 @@ END
 // Track if PC knows about Hephernaan being an agent of the Umbral Accord (1=knows face, 2=knows face and name) //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 REPLACE_ACTION_TEXT BDSCRY ~SetGlobal("bd_sddd12_hood","LOCALS",1)~ ~SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",1) SetGlobal("bd_sddd12_hood","LOCALS",1)~
+
+/* - deprecated - will be checked via Edwin's script.
 ALTER_TRANS BDSCRY
 	BEGIN 3 END
 	BEGIN 0 END
@@ -234,6 +256,9 @@ ALTER_TRANS BDSCRY
 EXTEND_BOTTOM BDSCRY 3
 	IF ~IsValidForPartyDialogue("EDWIN")~ THEN DO ~SetGlobal("BD_SDDD12_CLOUDY","MYAREA",1) SetGlobal("bd_sddd12_hood","LOCALS",1) SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",1) ActionOverride("EDWIN",SetGlobal("#L_SoDStat_HephUmbral","LOCALS",1)) StartCutSceneMode() StartCutSceneEx("bdscry05",FALSE)~ EXIT
 END
+*/
+
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Track if PC learned that Hephernaan is Caelar's advisor (1=knows name, 2=knows both name and face) //
@@ -281,12 +306,16 @@ APPEND BDEDWINJ
 	
 	IF ~~ THEN BEGIN OF_COURSE_1
 		SAY @2066 /* ~Of course I have.  I always am.~ */
-		IF ~~ THEN DO ~SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",2) SetGlobal("#L_SodStat_HephAdvisor","GLOBAL",2)~ EXIT
+		IF ~~ THEN DO ~SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",2) 
+SetGlobal("#L_SoDStat_HephUmbral","LOCALS",2)
+SetGlobal("#L_SodStat_HephAdvisor","GLOBAL",2)~ EXIT
 	END
 	
 	IF ~~ THEN BEGIN OF_COURSE_2
 		SAY @2068 /* ~Of course.  You expected anything less from me? (I should hope not!)~ */
-		IF ~~ THEN DO ~SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",2) SetGlobal("#L_SodStat_HephAdvisor","GLOBAL",2)~ EXIT
+		IF ~~ THEN DO ~SetGlobal("#L_SoDStat_HephUmbral","GLOBAL",2)
+SetGlobal("#L_SoDStat_HephUmbral","LOCALS",2)
+ SetGlobal("#L_SodStat_HephAdvisor","GLOBAL",2)~ EXIT
 	END
 END
 

--- a/sodrtd/themedtweaks/scripts/sod_stat_edwin.baf
+++ b/sodrtd/themedtweaks/scripts/sod_stat_edwin.baf
@@ -1,0 +1,27 @@
+/* Detection: Edwin is in area */
+IF
+	InParty("Edwin")
+	CombatCounter(0)
+	!See([ENEMY])
+	!Dead("Edwin")
+	AreaCheck("bd1200")
+	Global("#L_SoDStat_HephUmbral","GLOBAL",0) //global variable, is set when player watches the scene
+	Global("#L_SoDStat_HephUmbral","LOCALS",0) //local variable for Edwin
+THEN
+	RESPONSE #100
+		SetGlobal("#L_SoDStat_HephUmbral","LOCALS",1)
+END
+
+/* reset variable: Edwin is not in area or can't watch the scene */
+IF
+	OR(3) 
+		!InParty("Edwin")
+		Dead("Edwin")
+		!AreaCheck("bd1200")
+	CombatCounter(0)
+	!See([ENEMY])
+	Global("#L_SoDStat_HephUmbral","LOCALS",1)
+THEN
+	RESPONSE #100
+		SetGlobal("#L_SoDStat_HephUmbral","LOCALS",0)
+END

--- a/sodrtd/themedtweaks/tpa/sod_stat_options.tpa
+++ b/sodrtd/themedtweaks/tpa/sod_stat_options.tpa
@@ -67,3 +67,6 @@ DEFINE_ACTION_FUNCTION sod_stat_options BEGIN
 	EXTEND_BOTTOM ~BD0102.BCS~ ~%mod_root%/scripts/sod_stat_options_bd0102.baf~ USING ~%tra_loc%/%s/sod_stat_other.tra~	// Prompt PC to talk to Eltan about Dauston
 	EXTEND_BOTTOM ~BD1200.BCS~ ~%mod_root%/scripts/sod_stat_options_bd1200.baf~ USING ~%tra_loc%/%s/sod_stat_other.tra~ // Have Edwin expose Hephernaan
 END
+
+	//patch Edwin't script
+	EXTEND_BOTTOM ~BDEDWIN.BCS~ ~%mod_root%/scripts/sod_stat_edwin.baf~

--- a/sodrtd/tpa/include_reply_options.tpa
+++ b/sodrtd/tpa/include_reply_options.tpa
@@ -60,12 +60,8 @@ GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",2)~ + @222 /* It seems the crusaders wa
 GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",4)~ + @208 /* You are aware that Caelar *will* march her crusade into Avernus, though? */ DO ~SetGlobal("C#RtD_CoalCaelarPlan","GLOBAL",4) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_01
 /* if PC knows that Caelar is planning on marching into Avernus AND Hephernaan is working for a fiend, they can speculate that they are planning on opening a portal to Avernus */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2)
-	Global("C#RtD_CaelarPlan","GLOBAL",2)
-	Global("C#RtD_CaelarPlan","GLOBAL",3)
-OR(2)
-	GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
-	GlobalGT("C#RtD_KnowsPortalBlood","GLOBAL",0)
++ ~Global("C#RtD_CaelarPlan","GLOBAL",3)
+GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_KnowsPortalBlood","GLOBAL",0) //so reply options will not be doubled
 !Global("C#RtD_CoalCaelarPlan","GLOBAL",6)~ + @278 /* I have reasons to believe that Caelar is planning on opening a portal to Avernus to march her army into it. */ DO ~
 SetGlobal("C#RtD_CaelarPlan","GLOBAL",4) //no _SET
@@ -158,7 +154,7 @@ Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
 GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @211 /* I have disturbing news. Caelar's advisor Hephernaan is apparently working for a fiend who is planning on crossing into the Material Prime! */ DO ~
+!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
 //	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
 //	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
@@ -326,12 +322,8 @@ GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",2)~ + @222 /* It seems the crusaders wa
 GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",4)~ + @208 /* You are aware that Caelar *will* march her crusade into Avernus, though? */ DO ~SetGlobal("C#RtD_CoalCaelarPlan","GLOBAL",4) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_01
 /* if PC knows that Caelar is planning on marching into Avernus AND Hephernaan is working for a fiend, they can speculate that they are planning on opening a portal to Avernus */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2)
-	Global("C#RtD_CaelarPlan","GLOBAL",2)
-	Global("C#RtD_CaelarPlan","GLOBAL",3)
-OR(2)
-	GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
-	GlobalGT("C#RtD_KnowsPortalBlood","GLOBAL",0)
++ ~Global("C#RtD_CaelarPlan","GLOBAL",3)
+GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_KnowsPortalBlood","GLOBAL",0) //so reply options will not be doubled
 !Global("C#RtD_CoalCaelarPlan","GLOBAL",6)~ + @278 /* I have reasons to believe that Caelar is planning on opening a portal to Avernus to march her army into it. */ DO ~
 SetGlobal("C#RtD_CaelarPlan","GLOBAL",4) //no _SET
@@ -423,7 +415,7 @@ Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
 GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @211 /* I have disturbing news. Caelar's advisor Hephernaan is apparently working for a fiend who is planning on crossing into the Material Prime! */ DO ~
+!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
 //	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
 //	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
@@ -590,12 +582,8 @@ GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",2)~ + @222 /* It seems the crusaders wa
 GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",4)~ + @208 /* You are aware that Caelar *will* march her crusade into Avernus, though? */ DO ~SetGlobal("C#RtD_CoalCaelarPlan","GLOBAL",4) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_02
 /* if PC knows that Caelar is planning on marching into Avernus AND Hephernaan is working for a fiend, they can speculate that they are planning on opening a portal to Avernus */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2)
-	Global("C#RtD_CaelarPlan","GLOBAL",2)
-	Global("C#RtD_CaelarPlan","GLOBAL",3)
-OR(2)
-	GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
-	GlobalGT("C#RtD_KnowsPortalBlood","GLOBAL",0)
++ ~Global("C#RtD_CaelarPlan","GLOBAL",3)
+GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_KnowsPortalBlood","GLOBAL",0) //so reply options will not be doubled
 !Global("C#RtD_CoalCaelarPlan","GLOBAL",6)~ + @278 /* I have reasons to believe that Caelar is planning on opening a portal to Avernus to march her army into it. */ DO ~
 SetGlobal("C#RtD_CaelarPlan","GLOBAL",4) //no _SET
@@ -687,7 +675,7 @@ Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
 GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @211 /* I have disturbing news. Caelar's advisor Hephernaan is apparently working for a fiend who is planning on crossing into the Material Prime! */ DO ~
+!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
 //	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
 //	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
@@ -855,12 +843,8 @@ GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",2)~ + @222 /* It seems the crusaders wa
 GlobalLT("C#RtD_CoalCaelarPlan","GLOBAL",4)~ + @208 /* You are aware that Caelar *will* march her crusade into Avernus, though? */ DO ~SetGlobal("C#RtD_CoalCaelarPlan","GLOBAL",4) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_03
 /* if PC knows that Caelar is planning on marching into Avernus AND Hephernaan is working for a fiend, they can speculate that they are planning on opening a portal to Avernus */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2)
-	Global("C#RtD_CaelarPlan","GLOBAL",2)
-	Global("C#RtD_CaelarPlan","GLOBAL",3)
-OR(2)
-	GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
-	GlobalGT("C#RtD_KnowsPortalBlood","GLOBAL",0)
++ ~Global("C#RtD_CaelarPlan","GLOBAL",3)
+GlobalGT("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_KnowsPortalBlood","GLOBAL",0) //so reply options will not be doubled
 !Global("C#RtD_CoalCaelarPlan","GLOBAL",6)~ + @278 /* I have reasons to believe that Caelar is planning on opening a portal to Avernus to march her army into it. */ DO ~
 SetGlobal("C#RtD_CaelarPlan","GLOBAL",4) //no _SET
@@ -952,7 +936,7 @@ Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
 GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @211 /* I have disturbing news. Caelar's advisor Hephernaan is apparently working for a fiend who is planning on crossing into the Material Prime! */ DO ~
+!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
 //	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
 //	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script

--- a/sodrtd/translations/english/dialogue.tra
+++ b/sodrtd/translations/english/dialogue.tra
@@ -170,6 +170,10 @@
 @290  = ~[Corporal Bence Duncan]So, what now?~
 @291  = ~[Corporal Bence Duncan]Do you have more you can tell us about Caelar's plans?~
 
+/* new for v0.8 (Beta) */
+/* @292 also used in "include_reply_options.tph" */
+@292  = ~[PC Reply]I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in league with a fiend somehow.~
+
 /* add_consistency_replyoptions.d */
 @500  = ~[PC Reply]Yes, I think I know what happened there.~
 @501  = ~[PC Reply]I will not help you open a portal to Avernus, Caelar. This is madness.~
@@ -229,7 +233,7 @@
 @1516 = ~[Torsin De Lancie]This might be a clue as to why Caelar has such an interest in getting her hands onto you - alive.~
 @1517 = ~[Torsin De Lancie]We also know what she needs you for - your blood, to be precise. She needs your blood to open the portal to Avernus beneath Dragonspear Castle!~
 @1518 = ~[Torsin De Lancie]This is important news, as it clarifies Caelar's motivation with regard to you, <CHARNAME>. It is evident she needs your blood to open the portal to Avernus beneath Dragonspear Castle!~
-@1519 = ~[Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking mob - this is about preventing a second fiend war!~
+@1519 = ~[Marshal Nederlok]The new intel gives our fight against Caelar and her crusade a completely new meaning. This is not about stopping a ransacking mob - this is about preventing a third fiend war!~
 @1520 = ~[Torsin De Lancie]With this it is imperative for Caelar's crusade to get to you - alive. And this leaves us with a glaring problem, now that you are here, <CHARNAME>.~
 @1521 = ~[Torsin De Lancie]It seems now that not only was morale shaken by your Bhaal heritage. It also is a real danger to all of us, if what we know about the dormant portal beneath Dragonspear Castle is true!~
 @1522 = ~[Torsin De Lancie]If the crusaders get their hands on you... It was madness, letting you come here! We need to keep you in the camp, away from people's eyes... or send you far away!~

--- a/sodrtd/translations/french/dialogue.tra
+++ b/sodrtd/translations/french/dialogue.tra
@@ -169,6 +169,10 @@
 @290 = ~[Caporal Bence Duncan]Et maintenant, qu'allons-nous faire ?~
 @291 = ~[Caporal Bence Duncan]Avez-vous d'autres informations à nous fournir concernant les projets de Caelar ?~ 
 
+/* new for v0.8 (Beta) */
+/* @292 also used in "include_reply_options.tph" */
+@292  = ~[PC Reply]J'ai vu quelque chose d'inquiétant qui me fait penser que Hephernaan, le conseiller de Caelar, est peut-être de mèche avec un démon.~
+
 
 /* add_consistency_replyoptions.d */
 @500  = ~[PC Reply]Oui, je pense savoir ce qui s'est passé là-bas.~
@@ -229,7 +233,7 @@
 @1516 = ~[Torsin De Lancie]Ceci pourrait être un indice sur la raison pour laquelle Caelar désire tant mettre la main sur vous - vivant.~ ~Ceci pourrait être un indice sur la raison pour laquelle Caelar désire tant mettre la main sur vous - vivante.~
 @1517 = ~[Torsin De Lancie]Nous savons aussi pourquoi elle a besoin de vous - et plus spécifiquement de votre sang. Son objectif est d'ouvrir un portail vers Avernus, sous le château Paldragon !~
 @1518 = ~[Torsin De Lancie]C'est une nouvelle de la plus haute importance, elle clarifie les intentions de Caelar à votre égard, <CHARNAME>. Il est évident que l'ouverture du portail vers Avernus, nécessite votre sang !~
-@1519 = ~[Marshal Nederlok]Ces informations renouvellent notre détermination à combattre Caelar et sa croisade. Il ne s'agit plus d'arrêter une troupe de pillards - mais d'empêcher une seconde guerre contre les démons !~
+@1519 = ~[Marshal Nederlok]Ces informations renouvellent notre détermination à combattre Caelar et sa croisade. Il ne s'agit plus d'arrêter une troupe de pillards - mais d'empêcher une troisième guerre contre les démons !~
 @1520 = ~[Torsin De Lancie]De plus, il est impératif pour Caelar de vous récupérer - vivant. Ce qui nous amène aux complications que provoque votre présence, <CHARNAME>.~ ~De plus, il est impératif pour Caelar de vous récupérer - vivante. Ce qui nous amène aux complications que provoque votre présence, <CHARNAME>.~
 @1521 = ~[Torsin De Lancie]Il semble que votre héritage ne soit plus seulement dangereux pour le moral des troupes. La menace qui pèse sur nous aujourd'hui est bien plus grande, si ce que nous avons appris à propos de ce portail en sommeil sous le château Paldragon est vrai !~
 @1522 = ~[Torsin De Lancie]Et si la croisade mettait la main sur vous... Quelle folie de vous laisser nous rejoindre ici ! Nous devons vous confiner dans le camp, à l'abri des regards... ou vous envoyer le plus loin possible !~

--- a/sodrtd/translations/german/dialogue.tra
+++ b/sodrtd/translations/german/dialogue.tra
@@ -167,6 +167,14 @@
 @290  = ~[Corporal Bence Duncan]Und nun?~
 @291  = ~[Corporal Bence Duncan]Gibt es weitere Informationen über Caelars Pläne, die Ihr uns berichten könnt?~
 
+
+
+/* new for v0.8 (Beta) */
+
+/* @292 also used in "include_reply_options.tph" */
+
+@292  = ~[PC Reply]Ich wurde durch Zufall Zeuge einer Szene die den verstörenden Schluss zulässt, dass Ifearnan irgendwie mit einem Teufel im Bunde ist!~
+
 @500    = ~[PC reply]Ja, ich glaube, ich weiß, was da passiert ist.~
 @501    = ~[PC rely]Ich werde Euch nicht helfen, ein Portal nach Avernus zu öffnen, Caelar. Das ist Wahnsinn.~
 @502    = ~[PC reply]Ich glaube, dass Caelars wahres Ziel darin besteht, ihren Onkel Aun zu befreien, der wegen ihr in Avernus gefangen war.~
@@ -221,7 +229,7 @@
 @1516   = ~[Torsin De Lancie]Das könnte ein Hinweis darauf sein, warum Caelar ein solches Interesse daran hat, Euch lebend in die Finger zu bekommen.~
 @1517   = ~[Torsin De Lancie]Wir wissen auch, wofür sie Euch braucht – Euer Blut, um genau zu sein. Sie braucht Euer Blut, um das Portal nach Avernus unter Burg Drachenspeer zu öffnen!~
 @1518   = ~[Torsin De Lancie]Dies ist eine wichtige Nachricht, denn sie verdeutlicht Caelars Beweggründe in Bezug auf Euch, <CHARNAME>. Es ist offensichtlich, dass sie Euer Blut braucht, um das Portal nach Avernus unterhalb Burg Drachenspeer zu öffnen!~
-@1519   = ~[Marshal Nederlok]Die neuen Informationen geben unserem Kampf gegen Caelar und ihren Kreuzzug eine völlig neue Bedeutung. Hier geht es nicht darum, eine plündernde Bande zu stoppen. Hier geht es darum, einen zweiten Krieg gegen Teufel zu verhindern!~
+@1519   = ~[Marshal Nederlok]Die neuen Informationen geben unserem Kampf gegen Caelar und ihren Kreuzzug eine völlig neue Bedeutung. Hier geht es nicht darum, eine plündernde Bande zu stoppen. Hier geht es darum, einen dritten Krieg gegen Teufel zu verhindern!~
 @1520   = ~[Torsin De Lancie]Daher ist es für Caelars Kreuzzug unerlässlich, Zugriff auf Euch zu erlangen – und zwar lebend. Und damit stehen wir vor einem eklatanten Problem, jetzt da Ihr hier seid, <CHARNAME>.~
 @1521   = ~[Torsin De Lancie]Es scheint, dass nicht nur die Moral durch Euer Bhaal-Erbe erschüttert wurde. Es stellt auch eine echte Gefahr für uns alle dar, wenn es wahr ist, was wir über das inaktive Portal unter Burg Drachenspeer wissen!~
 @1522   = ~[Torsin De Lancie]Wenn die Kreuzzügler Euch in die Finger kriegen … Es war Wahnsinn, Euch hierher kommen zu lassen! Wir müssen Euch im Lager halten, weg von den Augen der Leute … oder Euch weit weg schicken!~

--- a/sodrtd/translations/italian/dialogue.tra
+++ b/sodrtd/translations/italian/dialogue.tra
@@ -170,6 +170,10 @@
 @290 = ~[Caporale Bence Duncan]E adesso?~
 @291 = ~[Caporale Bence Duncan]Hai altro da dirci sui piani di Caelar?~
 
+/* new for v0.8 (Beta) */
+/* @292 also used in "include_reply_options.tph" */
+@292  = ~[PC Reply]Ho visto qualcosa di inquietante che mi fa pensare che Hephernaan, il consigliere di Caelar, possa essere in qualche modo in combutta con un demone.~
+
 /* add_consistency_replyoptions.d */
 @500 = ~[Risposta del giocatore]Sì, credo di sapere cosa sia successo lì.~
 @501 = ~[Risposta del giocatore]Non ti aiuterò ad aprire un portale per Avernus, Caelar. È una follia.~
@@ -229,7 +233,7 @@
 @1516 = ~[Torsin De Lancie]Questo potrebbe essere un indizio del motivo per cui Caelar è così interessato a mettere le mani su di te... in salute.~
 @1517 = ~[Torsin De Lancie]Sappiamo anche perché ha bisogno di te, in particolare del tuo sangue. Il suo obiettivo è aprire un portale per Avernus, sotto il Castello Dragonspear!~
 @1518 = ~[Torsin De Lancie]Questa è una notizia della massima importanza, che chiarisce le intenzioni di Caelar nei tuoi confronti, <CHARNAME>. È ovvio che l'apertura del portale per Avernus richiede il tuo sangue!~
-@1519 = ~[Maresciallo Nederlok]Queste informazioni rinnovano la nostra determinazione a combattere Caelar e la sua crociata. Non si tratta più di fermare un gruppo di razziatori, ma di impedire una seconda guerra contro i demoni!~
+@1519 = ~[Maresciallo Nederlok]Queste informazioni rinnovano la nostra determinazione a combattere Caelar e la sua crociata. Non si tratta più di fermare un gruppo di razziatori, ma di impedire una terza guerra contro i demoni!~
 @1520 = ~[Torsin De Lancie]Inoltre, è imperativo per Caelar catturarti... e non ucciderti. E questo ci lascia con un problema evidente, ora che sei qui, <CHARNAME>.~
 @1521 = ~[Torsin De Lancie]Ora sembra che non solo il morale sia stato scosso dal tuo retaggio in quanto Progenie di Bhaal. È anche un pericolo reale per tutti noi, se quello che sappiamo sul portale dormiente sotto il Castello Dragonspear è vero!~
 @1522 = ~[Torsin De Lancie]Se i crociati ti mettono le mani addosso... È stata una follia lasciarti venire qui! Dobbiamo tenerti nell'accampamento, lontano dagli occhi della gente... o mandarti lontano!~


### PR DESCRIPTION
- Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.
- Dialogue with officers in bd3000.are should not skip parts if PC has nothing to report, and thre should be no doubled reply options.
- Viconia's or Glint's interjection into PC's self-talk about crusader camp "blessing" should not break the dialogue.
- Marshal Nederlok should be aware there were already two fiend wars at Dragonspear Castle.
- Sir Deggernaut's dialogue should not double reply options.
- Optimized variable triggers for PC's conclusions regarding Caelar's plans.