### PR TITLE
update to v1

### DIFF
--- a/sodrtd/dialogues/add_additional_infopoints.d
+++ b/sodrtd/dialogues/add_additional_infopoints.d
@@ -1,3 +1,27 @@
+/* additional possibility to learn about Hephernaan's master */
+/* bddaeros 3
+  SAY #61357 /* ~Hephernaan got madder than a hornet in a helmet. He stormed off with Caelar trailing after him. When he came back, I saw him use that altar there to speak with some dark creature. The fiend spotted me—Hephernaan bound me right quick. I've been trapped ever since.~ [BD61357] */
+*/
+APPEND bddaeros 
+IF ~~ THEN hephernaan_fiend
+SAY @1023 /* ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~ */
+++ @1024 /* ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~ */ + hephernaan_fiend_01
+COPY_TRANS bddaeros 3
+END
+
+IF ~~ THEN hephernaan_fiend_01
+SAY @1025 /* ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~ */
+COPY_TRANS bddaeros 3
+END
+END //APPEND
+
+EXTEND_BOTTOM bddaeros 3
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",0)~ + @1026 /* [PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~ */ DO ~SetGlobal("C#RtD_HephernaanIdentity_SET","GLOBAL",1)
+SetGlobal("C#RtD_HephernaanFiend_SET","GLOBAL",2)
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + hephernaan_fiend
+END
+
+
 /* additional possibilities to inquiry about the crusade's motives 
 SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1) */
 

--- a/sodrtd/dialogues/add_inform_officers_basic.d
+++ b/sodrtd/dialogues/add_inform_officers_basic.d
@@ -428,6 +428,11 @@ SAY @67 /* ~We feared as much... cursed be that madwoman.~ */
 IF ~~ THEN + update_delancie_01
 END
 
+IF ~~ THEN update_delancie_17
+SAY @71 /* Hmm, I heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~  */
+IF ~~ THEN + update_delancie_01
+END
+
 END //APPEND
 
 
@@ -625,6 +630,11 @@ END
 
 IF ~~ THEN update_nederlok_17
 SAY @69 /* ~[Marshal Nederlok]Well, we suspected as much. Thank you for the confirmation.~ */
+IF ~~ THEN + update_nederlok_00
+END
+
+IF ~~ THEN update_nederlok_18
+SAY @72 /* ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~ */
 IF ~~ THEN + update_nederlok_00
 END
 

--- a/sodrtd/dialogues/add_sir_deggernaut_temp.d
+++ b/sodrtd/dialogues/add_sir_deggernaut_temp.d
@@ -149,8 +149,25 @@ GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
 /* "C#RtD_HephernaanName" = 1 - PC heard Hephernaan's name in connection with Caelar */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* "C#RtD_HephernaanVisual" = 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* "C#RtD_HephernaanVisual" */
+/* 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
+/* Global("C#RtD_HephernaanVisual","GLOBAL",1): PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
+/* this reply option includes a variable change for the PC's knowledge */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",1)
+Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO 
+~%Set_CheckHephernaanVisual_GT_0%
+SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2) //no _SET
+SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_05
+/* "C#RtD_HephernaanVisual" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",2)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO
+~%Set_CheckHephernaanVisual_GT_0%
+SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_05
 /* "C#RtD_CaelarBetrayal" 
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
@@ -176,14 +193,10 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~%Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2% SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanVisual","GLOBAL",1): After seeing the scry pool scene
-Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
-//## !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)
-+ ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
-	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
-GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
 !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~%Set_CheckHephernaanFiend_GT_0%
 %Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2%

--- a/sodrtd/dialogues/add_sir_deggernaut_temp.d
+++ b/sodrtd/dialogues/add_sir_deggernaut_temp.d
@@ -173,40 +173,13 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_05
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
 /* not considered, PC wouldn't know it's important */
-/* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanFiend","GLOBAL",2) will be set by script automatically) */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-Global("C#RtD_HephernaanFiend","GLOBAL",0)
-GlobalLT("C#RtD_HephernaanBetrayal","GLOBAL",2)
-!Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~%Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2%
-	SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_01 
 /* "C#RtD_HephernaanBetrayal" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 /* only in case PC doesn't know that Hephernaan is working for a fiend [Global("C#RtD_HephernaanFiend","GLOBAL",0)], otherwise it's considered there. */
 + ~Global("C#RtD_HephernaanFiend","GLOBAL",0)
-Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
+Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~%Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2% SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
-Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~%Set_CheckHephernaanFiend_GT_0%
-%Set_CheckHephernaanBetrayal_1_OR_2% %Set_CheckCaelarBetrayal_1_OR_2%
-	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + information_04
 /* "C#RtD_HephernaanFiend" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
 /* considered with "C#RtD_HephernaanFiend" = 3 */
 /* "C#RtD_HephernaanFiend" = 3 - PC knows that Hephernaan [who is Caelar's advisor] is working for Belhifet */

--- a/sodrtd/dialogues/add_trans_action_general.d
+++ b/sodrtd/dialogues/add_trans_action_general.d
@@ -520,7 +520,7 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 /* bdireni 78
   SAY #63940 /* ~Perhaps you are right. Perhaps not. You do not speak for the Accord—and I do not bow to the demands of some broken fiend's lickspittle.~ [BD63940] */
 */
-/* scrying pool (Hooded man scene): knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* scrying pool (Hooded man scene): knows that [a man looking like] Hephernaan is working with Umbral Accord */
 ADD_TRANS_ACTION BDIRENI BEGIN 78 END BEGIN END ~SetGlobal("C#RtD_HephernaanVisual_SET","GLOBAL",1)
 SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 

--- a/sodrtd/dialogues/add_trans_action_general.d
+++ b/sodrtd/dialogues/add_trans_action_general.d
@@ -104,12 +104,6 @@ bddaeros: tells about portal, blood of a godly descendant, Hephernaan's fiend ma
 ADD_TRANS_ACTION BDDAEROS BEGIN 2 END BEGIN END ~SetGlobal("C#RtD_CaelarPlan_SET","GLOBAL",4)
 SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 
-/* bddaeros 3
-  SAY #61357 /* ~Hephernaan got madder than a hornet in a helmet. He stormed off with Caelar trailing after him. When he came back, I saw him use that altar there to speak with some dark creature. The fiend spotted me—Hephernaan bound me right quick. I've been trapped ever since.~ [BD61357] */
-*/
-ADD_TRANS_ACTION BDDAEROS BEGIN 3 END BEGIN END ~SetGlobal("C#RtD_HephernaanFiend_SET","GLOBAL",1)
-SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
-
 /* bddaeros 5
   SAY #61367 /* ~I don't know. Probably. I overheard Hephernaan say Caelar's blood was too weak, too diluted by generations. A god's direct descendent? Open a vein and that portal could pop right open.~ [BD61367] */
 */

--- a/sodrtd/dialogues/sir_deggernaut_tagg_information_temp.d
+++ b/sodrtd/dialogues/sir_deggernaut_tagg_information_temp.d
@@ -40,9 +40,9 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",2)~ THEN @236 /* We know that her advisor Hephernaan is betraying her. */
 DO ~%Set_CheckHephernaanBetrayal_1_OR_2% SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",1)
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 
 /* "C#RtD_CoalHephernaanFiend" */
-SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 == C#RtDdeg IF ~%CheckHephernaanFiend_GT_0% GlobalGT("C#RtD_CoalHephernaanFiend","GLOBAL",0)
 //OR(2)
 //Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)
@@ -57,6 +57,12 @@ Global("C#RtD_CoalHephernaanFiend","GLOBAL",4)~ THEN ~Hephernaan is working for 
 DO ~SetGlobal("##_SET","GLOBAL",1)
 SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 */
+
+/* "C#RtD_CoalHephernaanVisual" */
+== C#RtDdeg IF ~%CheckHephernaanVisual_GT_0% GlobalGT("C#RtD_CoalHephernaanVisual","GLOBAL",0)
+~ THEN@294 /* Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far. */
+DO ~%Set_CheckHephernaanVisual_GT_0% SetGlobal("C#RtD_HephernaanVisual_SET","GLOBAL",1)
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~
 
 /* "C#RtD_CoalCaelarGodBless" */
 == C#RtDdeg IF ~%CheckCaelarGodBless_1% Global("C#RtD_CoalCaelarGodBless","GLOBAL",1)~ THEN @238 /* We heard rumors about Caelar being divinely blessed, but we do not know how exactly. */

--- a/sodrtd/docs/note_to_translators.txt
+++ b/sodrtd/docs/note_to_translators.txt
@@ -5,8 +5,8 @@ All tra files are in utf-8 without BOM.
 The files "sod_stat_other.tra" and "sod_stat_weak_poison.tra" are from and therefore also in Lauriel's mod "Themed Tweaks".
 
 
-New for v1:
+New for v1 (all languages complete):
 -Additions of variable descriptions and note for component 9 in readme
 
--in dialogue.tra: lines @71, @72, @293, @294
+-in dialogue.tra: lines @71, @72, @293, @294, @1023 - @1026
 -in game.tra: line @10038

--- a/sodrtd/docs/note_to_translators.txt
+++ b/sodrtd/docs/note_to_translators.txt
@@ -3,3 +3,10 @@ Notes to translators:
 All tra files are in utf-8 without BOM.
 
 The files "sod_stat_other.tra" and "sod_stat_weak_poison.tra" are from and therefore also in Lauriel's mod "Themed Tweaks".
+
+
+New for v1:
+-Additions of variable descriptions and note for component 9 in readme
+
+-in dialogue.tra: lines @71, @72, @293, @294
+-in game.tra: line @10038

--- a/sodrtd/docs/outline_sod_variables.txt
+++ b/sodrtd/docs/outline_sod_variables.txt
@@ -128,7 +128,12 @@ Overall trigger variables - ONLY to be used as triggers in other mods:
 1 - PC heard Hephernaan's name in connection with Caelar
 
 "C#RtD_HephernaanVisual"
-1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend
+1 - PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord
+
+"C#RtD_CoalHephernaanVisual"
+1 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - PC told them
+2 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - heard it elsewhere 
 
 "C#RtD_KnowsAunArgent"
 1 - PC knows that Caelar had an uncle named Aun and something happened

--- a/sodrtd/readme.sodrtd.French.txt
+++ b/sodrtd/readme.sodrtd.French.txt
@@ -114,7 +114,7 @@ Le composant 9 ajoute un personnage personnalisé, Sir Deggernaut, qui se dépla
 Sir Deggernaut peut être trouvé près des tentes des deux premiers camps, et près de Mizhena dans le grand camp de la coalition.
 Ce composant est facultatif et nécessite également les composants 4 "Les officiers sont plus attentifs.", ainsi que 6 "Le PC peut informer les officiers." 
 
-Please note: This was meant as a feature to simplify reporting to the officers, especially in the first two camps where Bence Duncan is not always present, but due to how Sir Deggernaut's dialogue is focussed on the status of information about the crusade, his presence could feel more like a debug feature, and less like a real ingame character.
+Remarque : cette fonctionnalité a été conçue pour faciliter la communication avec les officiers, en particulier dans les deux premiers camps où Bence Duncan n'est pas toujours présent, mais étant donné que le dialogue de Sir Deggernaut est focalisé sur les informations relatives à la croisade, sa présence peut donner l'impression d'être une fonctionnalité de débogage plutôt qu'un véritable personnage du jeu.
 
 
 Compatibilité
@@ -410,9 +410,10 @@ Using the variables with the postfix "_SET" ensures that knowledge is not lost: 
 
 CREDITS
 
+Frenzgyn - Italian translation (new lines v1)
 improb@bile - Italian translation (v0.7 Beta)
 jastey - author, main mod head
-JohnBob - French translation (v0.5 Beta)
+JohnBob - French translation (v1)
 Lauriel - author of component 1, ideas, design help, proofreading English (v0.1 Beta) 
 Machiavélique - proofreading French (v0.4 Beta)
 Shai Hulud - German translation (v0.2 Beta)

--- a/sodrtd/readme.sodrtd.French.txt
+++ b/sodrtd/readme.sodrtd.French.txt
@@ -114,6 +114,8 @@ Le composant 9 ajoute un personnage personnalisé, Sir Deggernaut, qui se dépla
 Sir Deggernaut peut être trouvé près des tentes des deux premiers camps, et près de Mizhena dans le grand camp de la coalition.
 Ce composant est facultatif et nécessite également les composants 4 "Les officiers sont plus attentifs.", ainsi que 6 "Le PC peut informer les officiers." 
 
+Please note: This was meant as a feature to simplify reporting to the officers, especially in the first two camps where Bence Duncan is not always present, but due to how Sir Deggernaut's dialogue is focussed on the status of information about the crusade, his presence could feel more like a debug feature, and less like a real ingame character.
+
 
 Compatibilité
 
@@ -233,13 +235,14 @@ PC's knowledge:
 0 - PC couldn't connect face and name of Hephernaan yet or didn't meet/hear about him at all
 1 - PC knows Hephernaan by name and face and that he is Caelar's advisor
 
--PC heard Hephernaan's Name ("C#RtD_HephernaanName"):
+--PC heard Hephernaan's Name ("C#RtD_HephernaanName"):
 0 - PC never heard Hephernaan's name
 1 - PC heard Hephernaan's name in connection with Caelar
 
---PC saw Hephernaan's Face ("C#RtD_HephernaanVisual"):
+--PC saw Hephernaan's Face in scrypool scene / knows he is working for Umbral Accord ("C#RtD_HephernaanVisual"):
 0 - PC never saw Hephernaan's face
 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend
+2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord
 
 --Aun's and Caelar's Story ("C#RtD_KnowsAunArgent"):
 0 - No knowledge that Caelar had an uncle named Aun and something happened 
@@ -339,6 +342,10 @@ Caelar being betrayed? ("C#RtD_CoalCaelarBetrayal"):
 
 --Who is "Hephernaan"? ("C#RtD_CoalHephernaanIdentity"):
 1 - Dukes and officers know Hephernaan by name and face and that he is Caelar's advisor - heard it elsewhere
+
+--Hephernaan's Face working for Umbral Accord ("C#RtD_CoalHephernaanVisual"):
+1 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - PC told them
+2 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - heard it elsewhere 
 
 --Aun's and Caelar's Story ("C#RtD_CoalKnowsAunArgent"):
 1 - Dukes and officers heard rumors about Caelar being disgraced from Aster Order at the same time as Aun vanished - PC told them
@@ -449,6 +456,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 
 HISTORY
+
+Version 1.0
+- Scrypool Scene with Hephernaan will no longer lead to hints about fiend master. PC can tell officers about "Umbral Accord" instead.
+- Scrypool Scene will no longer lead to conclusion that Hephrnaan is betraying Caelar.
+- Sir Deggernaut will have appropriate scripts in camps.
+- Added extra reply option to Daeros dialogue to learn about fiend master. Hearing about "dark creature in mirror" will no longer lead to this knowledge directly.
+- Variable "C#RtD_HephernaanVisual" has value of 2: "PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord"; added "C#RtD_CoalHephernaanVisual" accordingly; updated readme and docs with description.
+- Updated links in sodrtd.ini.
 
 Version 0.8 Beta
 - Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.

--- a/sodrtd/readme.sodrtd.english.txt
+++ b/sodrtd/readme.sodrtd.english.txt
@@ -409,9 +409,10 @@ Using the variables with the postfix "_SET" ensures that knowledge is not lost: 
 
 CREDITS
 
+Frenzgyn - Italian translation (new lines v1)
 improb@bile - Italian translation (v0.7 Beta)
 jastey - author, main mod head
-JohnBob - French translation (v0.5 Beta)
+JohnBob - French translation (v1)
 Lauriel - author of component 1, ideas, design help, proofreading English (v0.1 Beta) 
 Machiavélique - proofreading French (v0.4 Beta)
 Shai Hulud - German translation (v0.2 Beta)

--- a/sodrtd/readme.sodrtd.english.txt
+++ b/sodrtd/readme.sodrtd.english.txt
@@ -113,6 +113,9 @@ This component is optional.
 Component 9 adds a custom character, Sir Deggernaut, who moves along the campaign from camp to camp for direct communication so the PC can always tell their findings independent on avilability of original game officers due to campaign progress. His dialogue features also a possibility to ask him about the status of the officers' knowledge, where he will list everything the officers are aware of at this point - which might be more than the PC found out depending on campaign progress. 
 Sir Deggernaut can be found by the camp tents in the first two camps, and near Mizhena in the big coalition camp.
 This component is optional and also needs components 4 "Officers Are Aware", as well as 6 "PC can tell the officers". 
+Please note: This was meant as a feature to simplify reporting to the officers, especially in the first two camps where Bence Duncan is not always present, but due to how Sir Deggernaut's dialogue is focussed on the status of information about the crusade, his presence could feel more like a debug feature, and less like a real ingame character.
+
+ 
 
 
 COMPATIBILITY NOTE
@@ -230,13 +233,14 @@ PC's knowledge:
 0 - PC couldn't connect face and name of Hephernaan yet or didn't meet/hear about him at all
 1 - PC knows Hephernaan by name and face and that he is Caelar's advisor
 
--PC heard Hephernaan's Name ("C#RtD_HephernaanName"):
+--PC heard Hephernaan's Name ("C#RtD_HephernaanName"):
 0 - PC never heard Hephernaan's name
 1 - PC heard Hephernaan's name in connection with Caelar
 
---PC saw Hephernaan's Face ("C#RtD_HephernaanVisual"):
+--PC saw Hephernaan's Face in scrypool scene / knows he is working for Umbral Accord ("C#RtD_HephernaanVisual"):
 0 - PC never saw Hephernaan's face
 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend
+2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord
 
 --Aun's and Caelar's Story ("C#RtD_KnowsAunArgent"):
 0 - No knowledge that Caelar had an uncle named Aun and something happened 
@@ -336,6 +340,11 @@ Caelar being betrayed? ("C#RtD_CoalCaelarBetrayal"):
 
 --Who is "Hephernaan"? ("C#RtD_CoalHephernaanIdentity"):
 1 - Dukes and officers know Hephernaan by name and face and that he is Caelar's advisor - heard it elsewhere
+
+--Hephernaan's Face working for Umbral Accord ("C#RtD_CoalHephernaanVisual"):
+1 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - PC told them
+2 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - heard it elsewhere 
+
 
 --Aun's and Caelar's Story ("C#RtD_CoalKnowsAunArgent"):
 1 - Dukes and officers heard rumors about Caelar being disgraced from Aster Order at the same time as Aun vanished - PC told them
@@ -446,6 +455,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 
 HISTORY
+
+Version 1.0
+- Scrypool Scene with Hephernaan will no longer lead to hints about fiend master. PC can tell officers about "Umbral Accord" instead.
+- Scrypool Scene will no longer lead to conclusion that Hephrnaan is betraying Caelar.
+- Sir Deggernaut will have appropriate scripts in camps.
+- Added extra reply option to Daeros dialogue to learn about fiend master. Hearing about "dark creature in mirror" will no longer lead to this knowledge directly.
+- Variable "C#RtD_HephernaanVisual" has value of 2: "PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord"; added "C#RtD_CoalHephernaanVisual" accordingly; updated readme and docs with description.
+- Updated links in sodrtd.ini.
 
 Version 0.8 Beta
 - Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.

--- a/sodrtd/readme.sodrtd.german.txt
+++ b/sodrtd/readme.sodrtd.german.txt
@@ -1,4 +1,4 @@
-﻿------------------------------------------------
+------------------------------------------------
 --- Road to Discovery für BG:SoD und EET:SoD ---
 ------------------------------------------------
 
@@ -108,11 +108,13 @@ Diese Komponente ist optional und benötigt außerdem die Komponenten 4 „Offiz
 Komponente 8 fügt ein paar weitere Möglichkeiten hinzu, um Informationen über Caelars Pläne zu sammeln, die in Komponente 1 „Stat-basierte Beobachtungen und Quest-Optionen von ‚Lauriel's Themed Tweaks Mod‘“ nicht berücksichtigt wurden. Zum Beispiel können die Kreuzzügler im Burglager genauer nach den Plänen des Kreuzzuges befragt werden und das „Segnungsritual“ im Lager an der Eberfellbrücke kann analysiert werden, sofern ein Kleriker oder Paladin in der Gruppe ist.
 Diese Komponente ist optional.
 
-9 Zusätzliche Offiziersreaktionen
+9 Zusätzliche Kommunikation mit Offizieren
 ---------------------------------------------
 Komponente 9 fügt einen benutzerdefinierten Charakter, Sir Deggernaut, hinzu, der sich während der Kampagne von Lager zu Lager bewegt, um eine direkte Kommunikation zu ermöglichen, sodass der HC seine Erkenntnisse immer mitteilen kann, unabhängig von der Erreichbarkeit der Offiziere des Originalspiels aufgrund des Kampagnenfortschritts. Sein Dialog bietet auch die Möglichkeit, ihn nach dem Wissensstand der Offiziere zu befragen, wobei er alles auflistet, was die Offiziere zu diesem Zeitpunkt wissen – was je nach Kampagnenfortschritt mehr sein kann, als der HC herausgefunden hat. 
 Sir Deggernaut ist bei den Lagerzelten in den ersten beiden Lagern und in der Nähe von Mizhena im großen Bündnislager zu finden.
-Diese Komponente ist optional und benötigt außerdem die Komponenten 4 „Offiziere wissen Bescheid“ und 6 „HC kann den Offizieren berichten“. 
+Diese Komponente ist optional und benötigt außerdem die Komponenten 4 „Offiziere wissen Bescheid“ und 6 „HC kann den Offizieren berichten“.
+
+Hinweis: Dies war als Erleichterung für das schnelle Berichten an die Offiziere gedacht, vor allem in den ersten beiden Lager, in denen Bence Duncan nicht immer anwesend ist. Durch den schematischen aufbau seines Dialoges kann es aber sein, dass Sir Deggernaut eher wie ein "Debug-Feature" wirkt als wie ein echter Spielcharakter.
 
 
 KOMPATIBILITÄTSHINWEIS
@@ -226,17 +228,18 @@ HCs Wissen:
 2 - HC weiß, dass Ifearnan [der Caelars Berater ist] für einen Teufel arbeitet, um das Portal zu öffnen 
 3 - HC weiß, dass Ifearnan [der Caelars Berater ist] für Belhifet arbeitet.
 
--Wer ist „Ifearnan“? ("C#RtD_HephernaanIdentity"):
+--Wer ist „Ifearnan“? ("C#RtD_HephernaanIdentity"):
 0 - HC konnte Gesicht und Namen von Ifearnan noch nicht zuordnen oder hat ihn noch nicht getroffen/gehört
 1 - HC kennt Ifearnan mit Namen und Gesicht und weiß, dass er Caelars Berater ist
 
--HC hat Ifearnans Namen gehört ("C#RtD_HephernaanName"):
+--HC hat Ifearnans Namen gehört ("C#RtD_HephernaanName"):
 0 - HC hat Ifearnans Namen nie gehört
 1 - HC hat Ifearnans Namen in Verbindung mit Caelar gehört
 
--HC sah Ifearnans Gesicht ("C#RtD_HephernaanVisual"):
+--HC sah Ifearnans Gesicht in Scrypool-Szene / weiß, dass er mit der Schattenübereinkunft zusammenarbeitet ("C#RtD_HephernaanVisual"):
 0 - HC hat das Gesicht von Ifearnan nie gesehen
-1 - HC weiß, dass [ein Mann, der aussieht wie] Ifearnan mit der Schattenübereinkunft/einem Teufel zusammenarbeitet
+1 - HC weiß, dass [ein Mann, der aussieht wie] Ifearnan mit der Schattenübereinkunft zusammenarbeitet
+2 - HC weiß, dass Ifearnan [der Caelars Berater ist] mit der Schattenübereinkunft zusammenarbeitet
 
 --Auns und Caelars Geschichte ("C#RtD_KnowsAunArgent"):
 0 - Keine Kenntnis, dass Caelar einen Onkel namens Aun hatte und etwas passiert ist 
@@ -250,7 +253,7 @@ HCs Wissen:
 1 - HC weiß, dass der vermummte Mann den HC wegen seines Bhaal-Erbes verfolgt
 2 - HC weiß, dass der vermummte Mann Skie getötet hat
 
--Portal unter Burg Drachenspeer und wie man es öffnet ("C#RtD_KnowsPortalBlood"):
+--Portal unter Burg Drachenspeer und wie man es öffnet ("C#RtD_KnowsPortalBlood"):
 0 - Keinerlei Wissen über das Portal
 1 - HC hat von einem Portal/Spalt in Burg Drachenspeer gehört
 2 - HC weiß, dass das Blut eines Bhaal-Kindes notwendig/ausreichend ist, um das Portal nach Avernus unter der Burg zu öffnen
@@ -335,7 +338,11 @@ Wird Caelar verraten? ("C#RtD_CoalCaelarBetrayal"):
 4 - Herzöge und Offiziere wissen, dass Ifearnan [der Caelars Brater ist] für Belhifet arbeitet – sie haben es woanders gehört 
 
 -Wer ist „Ifearnan“? ("C#RtD_CoalHephernaanIdentity"):
-1 - Herzöge und Offiziere kennen Ifearnan mit Namen und Gesicht und wissen, dass er Caelars Berater ist – habe es an anderer Stelle gehört
+1 - Herzöge und Offiziere kennen Ifearnan mit Namen und Gesicht und wissen, dass er Caelars Berater ist – sie haben es woanders gehört
+
+--Ifearnan arbeitet mit der Schattenübereinkunft zusammen ("C#RtD_CoalHephernaanVisual"):
+1 - Herzöge und Offiziere wissen, dass Ifearnan [der Caelars Brater ist] für Schattenübereinkunft arbeitet - der HC hat es ihnen gesagt
+2 - Herzöge und Offiziere wissen, dass Ifearnan [der Caelars Brater ist] für Schattenübereinkunft arbeitet - sie haben es woanders gehört 
 
 -Auns und Caelars Geschichte ("C#RtD_CoalKnowsAunArgent"):
 1 - Herzöge und Offiziere hörten Gerüchte über die Entlassung Caelars aus dem Orden der Aster zur gleichen Zeit, als Aun verschwand – HC erzählte es ihnen
@@ -446,6 +453,14 @@ https://www.gibberlings3.net/forums/topic/1649-community-filename-prefix-reserva
 
 
 ÄNDERUNGSHISTORIE
+
+Version 1.0
+- Scrypool Scene with Hephernaan will no longer lead to hints about fiend master. PC can tell officers about "Umbral Accord" instead.
+- Scrypool Scene will no longer lead to conclusion that Hephrnaan is betraying Caelar.
+- Sir Deggernaut will have appropriate scripts in camps.
+- Added extra reply option to Daeros dialogue to learn about fiend master. Hearing about "dark creature in mirror" will no longer lead to this knowledge directly.
+- Variable "C#RtD_HephernaanVisual" has value of 2: "PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord"; added "C#RtD_CoalHephernaanVisual" accordingly; updated readme and docs with description.
+- Updated links in sodrtd.ini.
 
 Version 0.8 Beta
 - Updated Themed Tweaks "Add stat-based observations and options" component to TT v0.4: Info about fallen paladin Dauston should be available if Corwin joins the party at first camp, too; Edwin's dialogue about scrying pool scene should close propely.

--- a/sodrtd/readme.sodrtd.german.txt
+++ b/sodrtd/readme.sodrtd.german.txt
@@ -407,9 +407,10 @@ Die Verwendung der Variablen mit dem Postfix „_SET“ stellt sicher, dass das 
 
 DANKSAGUNGEN
 
+Frenzgyn - Italian translation (new lines v1)
 improb@bile - italienische Übersetzung (v0.7 beta)
 jastey - Autor, Hauptverantwortliche für die Mod
-JohnBob - französische Übersetzung (v0.5 Beta)
+JohnBob - französische Übersetzung (v1)
 Lauriel - Autor von Komponente 1, Ideen, Designhilfe, Korrekturleser (v0.1 Beta)
 Machiavélique - Korrekturleser (französisch, v0.4 Beta)
 Shai Hulud - deutsche Übersetzung (v0.2 Beta)

--- a/sodrtd/scripts/hephernaanvisual_bd1200.baf
+++ b/sodrtd/scripts/hephernaanvisual_bd1200.baf
@@ -1,0 +1,23 @@
+/* PC will recognize Hephernaan if they already met them before watching scry pool scene. */
+
+/* Check variable: PC knew Hephernaan before watching the scry pool scene */
+IF
+	Global("C#RtD_HephernaanVisual","GLOBAL",0)
+	Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+	Global("C#RtD_HephernaanVisHelper","MYAREA",0)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_HephernaanVisHelper","MYAREA",1)
+		Continue()
+
+END
+
+IF
+	Global("C#RtD_HephernaanVisual","GLOBAL",1)
+	Global("C#RtD_HephernaanVisHelper","MYAREA",1)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2)
+		SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)
+		Continue()
+END

--- a/sodrtd/scripts/interconnections_bd1200.baf
+++ b/sodrtd/scripts/interconnections_bd1200.baf
@@ -6,7 +6,7 @@ SetGlobal("C#RtD_HephernaanVisual_SET","GLOBAL",1)
 
 Global("#L_SoDStat_HephUmbral","GLOBAL",2): PC knows about Hephernaan being an agent of the Umbral Accord 2 = name and face
 -> into area script of scry pool bd1200.BCS
-SetGlobal("C#RtD_HephernaanFiend_SET","GLOBAL",2)
+SetGlobal("C#RtD_HephernaanVisual_SET","GLOBAL",2)
 
 
 Global("#L_SodStat_HephAdvisor","GLOBAL",2):PC knows Hephernaan's face, name and that he is Caelar's advisor
@@ -26,11 +26,11 @@ THEN
 END
 IF
 	Global("#L_SoDStat_HephUmbral","GLOBAL",2)
-	!Global("C#RtD_HephernaanFiend_SET","GLOBAL",2)
-	GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
+	!Global("C#RtD_HephernaanVisual_SET","GLOBAL",2)
+	GlobalLT("C#RtD_HephernaanVisual","GLOBAL",2)
 THEN
 	RESPONSE #100
-		SetGlobal("C#RtD_HephernaanFiend_SET","GLOBAL",2)
+		SetGlobal("C#RtD_HephernaanVisual_SET","GLOBAL",2)
 		SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)
 		Continue()
 END

--- a/sodrtd/scripts/journalhandling.baf
+++ b/sodrtd/scripts/journalhandling.baf
@@ -301,9 +301,21 @@ THEN
 END
 */
 
+/* "C#RtD_HephernaanVisual" */
+/* 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
+IF
+	GlobalLT("C#RtD_HephernaanVisual_Journal","GLOBAL",2)
+	Global("C#RtD_HephernaanVisual","GLOBAL",2)
+THEN
+	RESPONSE #100
+//		EraseJournalEntry(##HephernaanVisual_1) 
+		AddJournalEntry(@10038,QUEST)
+		SetGlobal("C#RtD_HephernaanVisual_Journal","GLOBAL",2)
+END
+
 /* no journal entry
 /* "C#RtD_HephernaanVisual" */
-/* 1 - knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* 1 - knows that [a man looking like] Hephernaan is working with Umbral Accord */
 IF
 	Global("C#RtD_HephernaanVisual_Journal","GLOBAL",0)
 	Global("C#RtD_HephernaanVisual","GLOBAL",1)

--- a/sodrtd/scripts/variable_interconnections.baf
+++ b/sodrtd/scripts/variable_interconnections.baf
@@ -196,6 +196,27 @@ THEN
 		SetGlobal("C#RtD_KnowsPortalBlood","GLOBAL",3)
 END
 
+////////////////////////////////////////////////////////////////////////
+/* "C#RtD_HephernaanFiend" -> 2
+2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal  */
+
+/*
+1 - knows Hephernaan by name and face and that he is Caelar's advisor 
+"C#RtD_HephernaanIdentity" = 1
+1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+"C#RtD_HephernaanFiend" = 1
+THEN
+2 - knows that Hephernaan [who is Caelar's advisor] is betraying Caelar 
+"C#RtD_HephernaanFiend" -> 2
+*/
+IF
+	Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+	Global("C#RtD_HephernaanFiend","GLOBAL",1)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2)
+END
+
 
 ////////////////////////////////////////////////////////////////////////
 /* "C#RtD_HephernaanBetrayal" -> 2
@@ -219,6 +240,34 @@ THEN
 		SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2)
 END
 
+
+
+////////////////////////////////////////////////////////////////////////
+/* "C#RtD_HephernaanBetrayal" -> 2
+2 - knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
+
+/*
+1 - knows Hephernaan by name and face and that he is Caelar's advisor 
+"C#RtD_HephernaanIdentity" = 1
+1 - PC knows that [a man called] Hephernaan is betraying Caelar.
+"C#RtD_HephernaanBetrayal" = 1
+THEN
+2 - knows that Hephernaan [who is Caelar's advisor] is betraying Caelar 
+"C#RtD_HephernaanBetrayal" -> 2
+*/
+IF
+	Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+	Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2)
+END
+
+
+
+////////////////////////////////////////////////////////////////////////
+/* "C#RtD_CaelarBetrayal" -> 1
+1 - knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose */
 /* 
 IF
 2 - knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal 
@@ -248,13 +297,6 @@ END
 ///////////////////////////////////////////////////////////////
 /* "C#RtD_CaelarPlan" -> 4 */
 /* 4 - knows that they are planning on opening a portal at Dragonspear Castle to enter Avernus */
-
-/* no automated interconnection; all handled via dialogue */
-
-
-////////////////////////////////////////////////////////////////////////
-/* "C#RtD_HephernaanBetrayal" -> 2
-2 - knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 
 /* no automated interconnection; all handled via dialogue */
 

--- a/sodrtd/scripts/variable_interconnections.baf
+++ b/sodrtd/scripts/variable_interconnections.baf
@@ -198,21 +198,6 @@ END
 
 
 ////////////////////////////////////////////////////////////////////////
-/* "C#RtD_HephernaanFiend" -> 2 
-2 - knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
-
-/* for the rare case that the PC already told the officers that Hephernaan is betraying Caelar but witnesses the pool scene afterwards */
-IF
-	GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
-	Global("C#RtD_HephernaanVisual","GLOBAL",1)
-	Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-	Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
-THEN
-	RESPONSE #100
-		SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2)
-END
-
-////////////////////////////////////////////////////////////////////////
 /* "C#RtD_HephernaanBetrayal" -> 2
 2 - knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 

--- a/sodrtd/scripts/variablesetting/hephernaanvisual.baf
+++ b/sodrtd/scripts/variablesetting/hephernaanvisual.baf
@@ -1,7 +1,16 @@
 /* set the overal check variables. This is done ONCE */
 
 /* "C#RtD_HephernaanVisual" */
-/* 1 - knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
+IF
+	GlobalLT("C#RtD_HephernaanVisual","GLOBAL",2)
+	Global("C#RtD_HephernaanVisual_SET","GLOBAL",2)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2)
+END
+
+/* 1 - knows that [a man looking like] Hephernaan is working with Umbral Accord */
 IF
 	Global("C#RtD_HephernaanVisual","GLOBAL",0)
 	Global("C#RtD_HephernaanVisual_SET","GLOBAL",1)

--- a/sodrtd/scripts/variablesetting_coalition/hephernaanvisual_coalition.baf
+++ b/sodrtd/scripts/variablesetting_coalition/hephernaanvisual_coalition.baf
@@ -1,0 +1,20 @@
+/* set the overal check variables. This is done ONCE */
+
+/* "C#RtD_CoalHephernaanVisual" */
+/* 2 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - heard it elsewhere */
+IF
+	GlobalLT("C#RtD_CoalHephernaanVisual","GLOBAL",2)
+	Global("C#RtD_CoalHephernaanVisual_SET","GLOBAL",2)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",2)
+END
+/* 1 - Dukes and officers know that Hephernaan [who is Caelar's advisor] is working with Umbral Accord - PC told them */
+IF
+	Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)
+	Global("C#RtD_CoalHephernaanVisual_SET","GLOBAL",1)
+THEN
+	RESPONSE #100
+		SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1)
+END
+

--- a/sodrtd/sodrtd.ini
+++ b/sodrtd/sodrtd.ini
@@ -20,14 +20,14 @@ All in all, this mod is supposed to connect the dots the PC is able to tell abou
 For modders, this mod introduces a variable-based tracking system about the different levels of knowledge the PC and the coalition officers gain throughout the campaign, which could be used for own mods.
 
 # Web address of mod Homepage
-Homepage = 
+Homepage = https://www.gibberlings3.net/mods/other/road_to_discovery/
 
 #  Web address of mod dedicated forum or forum thread 
-Forum = 
+Forum = https://www.gibberlings3.net/forums/forum/231-road-to-discovery/
 
 # if you use Github.com (preferred hosting site), simply use github.com/AccountOrOrgName/RepositoryName    
 # If you use other hosting sites, please check requirements and put direct download link  
-Download = https://github.com/Gitjas/Road_To_Discovery_for_SoD
+Download = https://github.com/Gibberlings3/Road_To_Discovery_for_SoD
 
 # Type of LABELs used by the mod, read more here https://www.gibberlings3.net/forums/topic/32516-tutorial-what-is-label
 LabelType = GloballyUnique

--- a/sodrtd/sodrtd.tp2
+++ b/sodrtd/sodrtd.tp2
@@ -302,6 +302,11 @@ END
 EXTEND_BOTTOM ~bd1000.bcs~ ~...inlined/bd1000_add.baf~ EVALUATE_BUFFER
 
 
+/* PC will recognize Hephernaan if they already met them before watching scry pool scene. */
+EXTEND_BOTTOM ~BD1200.BCS~ ~sodrtd/scripts/hephernaanvisual_bd1200.baf~ 
+	EVALUATE_BUFFER
+
+
 /* bd3000.bcs */
 <<<<<<<< ...inlined/bd3000_add.baf
 /* Coalition camp bd3000.are. */

--- a/sodrtd/sodrtd.tp2
+++ b/sodrtd/sodrtd.tp2
@@ -3,7 +3,7 @@ BACKUP ~sodrtd/backup~
 AUTHOR ~https://baldurs-gate.de/index.php?resources/road-to-discovery-for-sod.59/~ 
 
 
-VERSION ~0.8 (Beta)~
+VERSION ~1.0pre~
 
 
 README ~sodrtd/readme.sodrtd.%LANGUAGE%.txt~ ~sodrtd/readme.sodrtd.english.txt~
@@ -110,7 +110,7 @@ BEGIN @100005 /* ~Main Component: Tracking System~ */
 <<<<<<<< .../inlined/journal_0.tph
 >>>>>>>>
 OUTER_SET strref_journal = eet_200000 + 31270 //59718 //59722 //59732 //66700 //67432 //59615
-APPEND_OUTER - ~.../inlined/journal_0.tph~ "ADD_JOURNAL EXISTING TITLE (#%strref_journal%) @10000 @10001 @10002 @10003 @10004 @10005 @10006 @10007 @10008 @10009 @10010 @10011 @10012 @10013 @10014 @10015 @10016 @10017 @10018 @10019 @10020 @10021 @10022 @10023 @10024 @10025 @10026 @10027 @10028 @10029 @10030 @10031 @10037 USING ~sodrtd/translations/%LANGUAGE%/game.tra~"
+APPEND_OUTER - ~.../inlined/journal_0.tph~ "ADD_JOURNAL EXISTING TITLE (#%strref_journal%) @10000 @10001 @10002 @10003 @10004 @10005 @10006 @10007 @10008 @10009 @10010 @10011 @10012 @10013 @10014 @10015 @10016 @10017 @10018 @10019 @10020 @10021 @10022 @10023 @10024 @10025 @10026 @10027 @10028 @10029 @10030 @10031 @10037 @10038 USING ~sodrtd/translations/%LANGUAGE%/game.tra~"
 INCLUDE ~.../inlined/journal_0.tph~
 
 
@@ -201,6 +201,7 @@ EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/caelarwan
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/hephernaanbetrayal_coalition.baf~ EVALUATE_BUFFER
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/hephernaanfiendmaster_coalition.baf~ EVALUATE_BUFFER
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/hephernaanidentity_coalition.baf~ EVALUATE_BUFFER
+EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/hephernaanvisual_coalition.baf~ EVALUATE_BUFFER
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/knowsaunargent_coalition.baf~ EVALUATE_BUFFER
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/knowshoodedman_coalition.baf~ EVALUATE_BUFFER
 EXTEND_BOTTOM ~c#rtd_ve.bcs~ ~sodrtd/scripts/variablesetting_coalition/knowsportalblood_coalition.baf~ EVALUATE_BUFFER
@@ -1048,6 +1049,7 @@ IF
 THEN
 	RESPONSE #100
 		CreateCreature("C#RtDdeg",[622.3442],0)
+		ActionOverride("C#RtDdeg",ChangeAIScript("bdfist",CLASS))
 		SetGlobal("C#RtD_SpawnDeggernaut","bd1000",1)
 END
 
@@ -1068,6 +1070,7 @@ IF
 THEN
 	RESPONSE #100
 		CreateCreature("C#RtDdeg",[2000.1506],6)
+		ActionOverride("C#RtDdeg",ChangeAIScript("bdasc2",CLASS))
 		SetGlobal("C#RtD_SpawnDeggernaut","bd3000",1)
 		Continue()
 END
@@ -1108,6 +1111,7 @@ IF
 THEN
 	RESPONSE #100
 		CreateCreature("C#RtDdeg",[373.3390],12)
+		ActionOverride("C#RtDdeg",ChangeAIScript("bdfist",CLASS))
 		SetGlobal("C#RtD_SpawnDeggernaut","bd7100",1)
 END
 IF

--- a/sodrtd/sodrtd.tp2
+++ b/sodrtd/sodrtd.tp2
@@ -3,7 +3,7 @@ BACKUP ~sodrtd/backup~
 AUTHOR ~https://baldurs-gate.de/index.php?resources/road-to-discovery-for-sod.59/~ 
 
 
-VERSION ~1.0pre~
+VERSION ~1.0~
 
 
 README ~sodrtd/readme.sodrtd.%LANGUAGE%.txt~ ~sodrtd/readme.sodrtd.english.txt~

--- a/sodrtd/tpa/include_checkvariables_sir_deggernaut_0.tpa
+++ b/sodrtd/tpa/include_checkvariables_sir_deggernaut_0.tpa
@@ -7,6 +7,7 @@ OUTER_SPRINT ~CheckHephernaanIdentity_1~ ~Global("C#RtD_SD_HI1","LOCALS",0)~
 OUTER_SPRINT ~CheckCaelarBetrayal_1_OR_2~ ~Global("C#RtD_SD_CB1_2","LOCALS",0)~
 OUTER_SPRINT ~CheckHephernaanBetrayal_1_OR_2~ ~Global("C#RtD_SD_HB1_2","LOCALS",0)~
 OUTER_SPRINT ~CheckHephernaanFiend_GT_0~ ~Global("C#RtD_SD_HF_GT0","LOCALS",0)~
+OUTER_SPRINT ~CheckHephernaanVisual_GT_0~ ~Global("C#RtD_SD_HV_GT0","LOCALS",0)~
 OUTER_SPRINT ~CheckCaelarGodBless_1~ ~Global("C#RtD_SD_GB1","LOCALS",0)~
 OUTER_SPRINT ~CheckCaelarGodBless_2_OR_3~ ~Global("C#RtD_SD_GB2_3","LOCALS",0)~
 OUTER_SPRINT ~CheckCaelarBhaalChild_1~ ~Global("C#RtD_SD_CBC1","LOCALS",0)~

--- a/sodrtd/tpa/include_checkvariables_sir_deggernaut_1.tpa
+++ b/sodrtd/tpa/include_checkvariables_sir_deggernaut_1.tpa
@@ -7,6 +7,7 @@ OUTER_SPRINT ~CheckHephernaanIdentity_1~ ~Global("C#RtD_SD_HI1","LOCALS",1)~
 OUTER_SPRINT ~CheckCaelarBetrayal_1_OR_2~ ~Global("C#RtD_SD_CB1_2","LOCALS",1)~
 OUTER_SPRINT ~CheckHephernaanBetrayal_1_OR_2~ ~Global("C#RtD_SD_HB1_2","LOCALS",1)~
 OUTER_SPRINT ~CheckHephernaanFiend_GT_0~ ~Global("C#RtD_SD_HF_GT0","LOCALS",1)~
+OUTER_SPRINT ~CheckHephernaanVisual_GT_0~ ~Global("C#RtD_SD_HV_GT0","LOCALS",1)~
 OUTER_SPRINT ~CheckCaelarGodBless_1~ ~Global("C#RtD_SD_GB1","LOCALS",1)~
 OUTER_SPRINT ~CheckCaelarGodBless_2_OR_3~ ~Global("C#RtD_SD_GB2_3","LOCALS",1)~
 OUTER_SPRINT ~CheckCaelarBhaalChild_1~ ~Global("C#RtD_SD_CBC1","LOCALS",1)~

--- a/sodrtd/tpa/include_checkvariables_sir_deggernaut_empty.tpa
+++ b/sodrtd/tpa/include_checkvariables_sir_deggernaut_empty.tpa
@@ -6,6 +6,7 @@ OUTER_SPRINT ~CheckHephernaanIdentity_1~ ~~
 OUTER_SPRINT ~CheckCaelarBetrayal_1_OR_2~ ~~
 OUTER_SPRINT ~CheckHephernaanBetrayal_1_OR_2~ ~~
 OUTER_SPRINT ~CheckHephernaanFiend_GT_0~ ~~
+OUTER_SPRINT ~CheckHephernaanVisual_GT_0~ ~~
 OUTER_SPRINT ~CheckCaelarGodBless_1~ ~~
 OUTER_SPRINT ~CheckCaelarGodBless_2_OR_3~ ~~
 OUTER_SPRINT ~CheckCaelarBhaalChild_1~ ~~

--- a/sodrtd/tpa/include_reply_options.tpa
+++ b/sodrtd/tpa/include_reply_options.tpa
@@ -119,15 +119,29 @@ GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
 /* "C#RtD_HephernaanName" = 1 - PC heard Hephernaan's name in connection with Caelar */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* "C#RtD_HephernaanVisual" = 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
-/* not considered. Just because it's nothing the PC would need to tell the officers. */
+/* "C#RtD_HephernaanVisual" */
+/* 1 - PC knows that [a man looking like] Hephernaan is working with Umbral Accord */
+/* not considered. Just because the PC wouldn't know it's important. */
+/* Global("C#RtD_HephernaanVisual","GLOBAL",1): PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
+/* this reply option includes a variable change for the PC's knowledge */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",1)
+Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~
+	SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2) //no _SET
+	SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_04
+/* "C#RtD_HephernaanVisual" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",2)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_04
 /* "C#RtD_CaelarBetrayal" 
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
 /* not considered, PC wouldn't know it's important */
 /* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanFiend","GLOBAL",2) will be set by script automatically) */
+(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanVisual","GLOBAL",2) will be set by script automatically) */
 /* this reply option includes a variable change for the PC's knowledge */
 + ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
@@ -146,13 +160,10 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanVisual","GLOBAL",1): After seeing the scry pool scene
-Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
-	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
-GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
 !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
@@ -380,8 +391,22 @@ GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
 /* "C#RtD_HephernaanName" = 1 - PC heard Hephernaan's name in connection with Caelar */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* "C#RtD_HephernaanVisual" = 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* "C#RtD_HephernaanVisual" */
+/* 1 - PC knows that [a man looking like] Hephernaan is working with UmbralAccord */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
+/* Global("C#RtD_HephernaanVisual","GLOBAL",1): PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
+/* this reply option includes a variable change for the PC's knowledge */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",1)
+Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~
+	SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2) //no _SET
+	SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_07
+/* "C#RtD_HephernaanVisual" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",2)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_07
 /* "C#RtD_CaelarBetrayal" 
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
@@ -407,13 +432,10 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanVisual","GLOBAL",1): After seeing the scry pool scene
-Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
-	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
-GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
 !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
@@ -640,8 +662,22 @@ GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
 /* "C#RtD_HephernaanName" = 1 - PC heard Hephernaan's name in connection with Caelar */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* "C#RtD_HephernaanVisual" = 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* "C#RtD_HephernaanVisual" */
+/* 1 - PC knows that [a man looking like] Hephernaan is working with UmbralAccord */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
+/* Global("C#RtD_HephernaanVisual","GLOBAL",1): PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
+/* this reply option includes a variable change for the PC's knowledge */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",1)
+Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~
+	SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2) //no _SET
+	SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_17
+/* "C#RtD_HephernaanVisual" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",2)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_17
 /* "C#RtD_CaelarBetrayal" 
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
@@ -667,13 +703,10 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_08
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanVisual","GLOBAL",1): After seeing the scry pool scene
-Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
-	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
-GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
 !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
@@ -901,8 +934,22 @@ GlobalGT("C#RtD_CoalKnowsPortalBlood","GLOBAL",4)
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
 /* "C#RtD_HephernaanName" = 1 - PC heard Hephernaan's name in connection with Caelar */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* "C#RtD_HephernaanVisual" = 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
+/* "C#RtD_HephernaanVisual" */
+/* 1 - PC knows that [a man looking like] Hephernaan is working with Umbral/a fiend */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
+/* Global("C#RtD_HephernaanVisual","GLOBAL",1): PC knows that [a man looking like] Hephernaan is working with Umbral Accord
+Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
+/* this reply option includes a variable change for the PC's knowledge */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",1)
+Global("C#RtD_HephernaanIdentity","GLOBAL",1)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~
+	SetGlobal("C#RtD_HephernaanVisual","GLOBAL",2) //no _SET
+	SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_18
+/* "C#RtD_HephernaanVisual" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord */
++ ~Global("C#RtD_HephernaanVisual","GLOBAL",2)
+Global("C#RtD_CoalHephernaanVisual","GLOBAL",0)~ + @293 /* ~I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~ */ DO ~SetGlobal("C#RtD_CoalHephernaanVisual","GLOBAL",1) 
+SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_18
 /* "C#RtD_CaelarBetrayal" 
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
@@ -928,13 +975,10 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_07
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanVisual","GLOBAL",1): After seeing the scry pool scene
-Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
+/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
 Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
 /* this reply option includes a variable change for the PC's knowledge */
-+ ~OR(2) Global("C#RtD_HephernaanVisual","GLOBAL",1) 
-	 Global("C#RtD_HephernaanFiend","GLOBAL",1)
-GlobalLT("C#RtD_HephernaanFiend","GLOBAL",2)
++ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
 Global("C#RtD_HephernaanIdentity","GLOBAL",1)
 !Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
 	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET

--- a/sodrtd/tpa/include_reply_options.tpa
+++ b/sodrtd/tpa/include_reply_options.tpa
@@ -140,19 +140,6 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_04
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
 /* not considered, PC wouldn't know it's important */
-/* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanVisual","GLOBAL",2) will be set by script automatically) */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-Global("C#RtD_HephernaanFiend","GLOBAL",0)
-GlobalLT("C#RtD_HephernaanBetrayal","GLOBAL",2)
-!Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~
-	SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_01 
 /* "C#RtD_HephernaanBetrayal" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 /* only in case PC doesn't know that Hephernaan is working for a fiend [Global("C#RtD_HephernaanFiend","GLOBAL",0)], otherwise it's considered there. */
 + ~Global("C#RtD_HephernaanFiend","GLOBAL",0)
@@ -160,19 +147,6 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
-Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
-	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_bence_04
 /* "C#RtD_HephernaanFiend" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
 /* considered with "C#RtD_HephernaanFiend" = 3 */
 /* "C#RtD_HephernaanFiend" = 3 - PC knows that Hephernaan [who is Caelar's advisor] is working for Belhifet */
@@ -412,19 +386,6 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_07
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
 /* not considered, PC wouldn't know it's important */
-/* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanFiend","GLOBAL",2) will be set by script automatically) */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-Global("C#RtD_HephernaanFiend","GLOBAL",0)
-GlobalLT("C#RtD_HephernaanBetrayal","GLOBAL",2)
-!Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~
-	SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_01
 /* "C#RtD_HephernaanBetrayal" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 /* only in case PC doesn't know that Hephernaan is working for a fiend [Global("C#RtD_HephernaanFiend","GLOBAL",0)], otherwise it's considered there. */
 + ~Global("C#RtD_HephernaanFiend","GLOBAL",0)
@@ -432,19 +393,6 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_01
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
-Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
-	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_corwin_04
 /* "C#RtD_HephernaanFiend" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
 /* considered with "C#RtD_HephernaanFiend" = 3 */
 /* "C#RtD_HephernaanFiend" = 3 - PC knows that Hephernaan [who is Caelar's advisor] is working for Belhifet */
@@ -682,19 +630,6 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_17
 1 - PC knows that Caelar is betrayed by someone in her crusade, that there is a deeper level to the crusade's purpose she has no influence on */
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
-/* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanFiend","GLOBAL",2) will be set by script automatically) */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-Global("C#RtD_HephernaanFiend","GLOBAL",0)
-GlobalLT("C#RtD_HephernaanBetrayal","GLOBAL",2)
-!Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~
-	SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_08 
 /* not considered, PC wouldn't know it's important */
 /* "C#RtD_HephernaanBetrayal" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 /* only in case PC doesn't know that Hephernaan is working for a fiend [Global("C#RtD_HephernaanFiend","GLOBAL",0)], otherwise it's considered there. */
@@ -703,19 +638,6 @@ Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_08
 /* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
 /* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
-Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
-	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_delancie_07
 /* "C#RtD_HephernaanFiend" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
 /* considered with "C#RtD_HephernaanFiend" = 3 */
 /* "C#RtD_HephernaanFiend" = 3 - PC knows that Hephernaan [who is Caelar's advisor] is working for Belhifet */
@@ -955,39 +877,11 @@ SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_18
 /* not considered as an own reply option. Is dealt with via "C#RtD_HephernaanBetrayal" */
 /* "C#RtD_HephernaanBetrayal" = 1 - PC knows that [a man called] Hephernaan is betraying Caelar */
 /* not considered, PC wouldn't know it's important */
-/* if PC knows about [a man called] Hephernaan betraying Caelar and knows who Hephernaan is, but doesn't know he is working for a fiend: 
-(If PC watches scry pool scene after this reply option, variable ("C#RtD_HephernaanFiend","GLOBAL",2) will be set by script automatically) */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanBetrayal","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-Global("C#RtD_HephernaanFiend","GLOBAL",0)
-GlobalLT("C#RtD_HephernaanBetrayal","GLOBAL",2)
-!Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",1)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~
-	SetGlobal("C#RtD_HephernaanBetrayal","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_07 
 /* "C#RtD_HephernaanBetrayal" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is betraying Caelar */
 /* only in case PC doesn't know that Hephernaan is working for a fiend [Global("C#RtD_HephernaanFiend","GLOBAL",0)], otherwise it's considered there. */
 + ~Global("C#RtD_HephernaanFiend","GLOBAL",0)
 Global("C#RtD_HephernaanBetrayal","GLOBAL",2)
 Global("C#RtD_CoalHephernaanBetrayal","GLOBAL",0)~ + @212 /* I have reasons to believe that Caelar's advisor Hephernaan is betraying Caelar. He has his own, dark plans with this crusade. */ DO ~SetGlobal("C#RtD_CoalHephernaanBetrayal","GLOBAL",1) SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_07
-/* "C#RtD_HephernaanFiend" = 1 - PC knows that [a man being called] Hephernaan is working for a fiend to open the portal */
-/* not considered. Just because it's nothing the PC would need to tell the officers. */
-/* Global("C#RtD_HephernaanFiend","GLOBAL",1): PC knows that [a man being called] Hephernaan is working for a fiend to open the portal
-Global("C#RtD_HephernaanIdentity","GLOBAL",1) knows who Hephernaan is. */
-/* this reply option includes a variable change for the PC's knowledge */
-+ ~Global("C#RtD_HephernaanFiend","GLOBAL",1)
-Global("C#RtD_HephernaanIdentity","GLOBAL",1)
-!Global("C#RtD_CoalHephernaanFiend","GLOBAL",1)~ + @292 /* ~I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in liege with a fiend of sorts.~ */ DO ~
-	SetGlobal("C#RtD_HephernaanFiend","GLOBAL",2) //no _SET
-//	SetGlobal("C#RtD_HephernaanBetrayal_SET","GLOBAL",2) will be set by script
-//	SetGlobal("C#RtD_CaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_CoalHephernaanFiend_SET","GLOBAL",1) 
-//	SetGlobal("C#RtD_CoalHephernaanBetrayal_SET","GLOBAL",1) will be set by script
-//	SetGlobal("C#RtD_CoalCaelarBetrayal_SET","GLOBAL",1) will be set by script
-	SetGlobal("C#RtD_VariableEvaluation","GLOBAL",1)~ + update_nederlok_06
 /* "C#RtD_HephernaanFiend" = 2 - PC knows that Hephernaan [who is Caelar's advisor] is working for a fiend to open the portal */
 /* considered with "C#RtD_HephernaanFiend" = 3 */
 /* "C#RtD_HephernaanFiend" = 3 - PC knows that Hephernaan [who is Caelar's advisor] is working for Belhifet */

--- a/sodrtd/tpa/include_setting_checkvariables_sir_deggernaut_1.tpa
+++ b/sodrtd/tpa/include_setting_checkvariables_sir_deggernaut_1.tpa
@@ -8,6 +8,7 @@ OUTER_SPRINT ~Set_CheckHephernaanIdentity_1~ ~SetGlobal("C#RtD_SD_HI1","LOCALS",
 OUTER_SPRINT ~Set_CheckCaelarBetrayal_1_OR_2~ ~SetGlobal("C#RtD_SD_CB1_2","LOCALS",1)~
 OUTER_SPRINT ~Set_CheckHephernaanBetrayal_1_OR_2~ ~SetGlobal("C#RtD_SD_HB1_2","LOCALS",1)~
 OUTER_SPRINT ~Set_CheckHephernaanFiend_GT_0~ ~SetGlobal("C#RtD_SD_HF_GT0","LOCALS",1)~
+OUTER_SPRINT ~Set_CheckHephernaanVisual_GT_0~ ~SetGlobal("C#RtD_SD_HV_GT0","LOCALS",1)~
 OUTER_SPRINT ~Set_CheckCaelarGodBless_1~ ~SetGlobal("C#RtD_SD_GB1","LOCALS",1)~
 OUTER_SPRINT ~Set_CheckCaelarGodBless_2_OR_3~ ~SetGlobal("C#RtD_SD_GB2_3","LOCALS",1)~
 OUTER_SPRINT ~Set_CheckCaelarBhaalChild_1~ ~SetGlobal("C#RtD_SD_CBC1","LOCALS",1)~

--- a/sodrtd/tpa/include_setting_checkvariables_sir_deggernaut_empty.tpa
+++ b/sodrtd/tpa/include_setting_checkvariables_sir_deggernaut_empty.tpa
@@ -7,6 +7,7 @@ OUTER_SPRINT ~Set_CheckHephernaanIdentity_1~ ~~
 OUTER_SPRINT ~Set_CheckCaelarBetrayal_1_OR_2~ ~~
 OUTER_SPRINT ~Set_CheckHephernaanBetrayal_1_OR_2~ ~~
 OUTER_SPRINT ~Set_CheckHephernaanFiend_GT_0~ ~~
+OUTER_SPRINT ~Set_CheckHephernaanVisual_GT_0~ ~~
 OUTER_SPRINT ~Set_CheckCaelarGodBless_1~ ~~
 OUTER_SPRINT ~Set_CheckCaelarGodBless_2_OR_3~ ~~
 OUTER_SPRINT ~Set_CheckCaelarBhaalChild_1~ ~~

--- a/sodrtd/translations/english/dialogue.tra
+++ b/sodrtd/translations/english/dialogue.tra
@@ -72,6 +72,10 @@
 @69   = ~[Marshal Nederlok]Well, we suspected as much. Thank you for the confirmation.~
 @70    = ~[PC reply]I have more information concerning Caelar's plans we need to discuss right now.~
 
+/* new in v1 */
+@71   = ~[Torsin De Lancie]Hmm, I never heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~
+@72   = ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~
+
 /* add_sir_deggernaut.d */
 @200  = ~[Sir Deggernaut (male)]Greetings, I am Sir Deggernaut. The Dukes decided to send me with you to monitor the progress of the coalition forces and keep the Dukes as well as our allies completely informed at all times. I will be here if you have anything you want the Dukes or the other coalition officers to know.~
 @201  = ~[Sir Deggernaut (male)]Is there anything you want to inform us about Caelar's crusade?~
@@ -174,6 +178,10 @@
 /* @292 also used in "include_reply_options.tph" */
 @292  = ~[PC Reply]I saw something disturbing that lets me think that Hephernaan, Caelar's advisor, might be in league with a fiend somehow.~
 
+/* new for v1 */
+@293  = ~[PC Reply]I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~
+@294  = ~[Sir Deggernaut (male)]Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far.~
+
 /* add_consistency_replyoptions.d */
 @500  = ~[PC Reply]Yes, I think I know what happened there.~
 @501  = ~[PC Reply]I will not help you open a portal to Avernus, Caelar. This is madness.~
@@ -212,6 +220,12 @@
 @1020 = ~[PC Selftalk](You noticed <PLAYER4>'s reaction to the performance and do not need any more information to know that this "blessing" is nothing special at all, and definitely not a protection by "the gods" as proclaimed by the priest carrying out the ritual.)~
 @1021 = ~[PC Selftalk](You noticed <PLAYER5>'s reaction to the performance and do not need any more information to know that this "blessing" is nothing special at all, and definitely not a protection by "the gods" as proclaimed by the priest carrying out the ritual.)~
 @1022 = ~[PC Selftalk](You noticed <PLAYER6>'s reaction to the performance and do not need any more information to know that this "blessing" is nothing special at all, and definitely not a protection by "the gods" as proclaimed by the priest carrying out the ritual.)~
+
+/* new for v1 */
+@1023 = ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~
+@1024 = ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~
+@1025 = ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~
+@1026 = ~[PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~
 
 /* add_reactions.d */
 @1500 = ~[Captain Corwin]And - we all know what would happen if the crusade would get their hands on you. I admit that's a strong motivation to ensure your safety as well, <CHARNAME>.~

--- a/sodrtd/translations/english/game.tra
+++ b/sodrtd/translations/english/game.tra
@@ -111,8 +111,12 @@ I was able to witness the "blessing ritual" in the crusader's camps with the mea
 @10037  = ~Important Events
 
 Who would have guessed. All high and mighty Caelar was disgraced from her Order of paladins - as a child no less. One of her uncles disappeared mysteriously around that time, too.~
+
+/* new in v1 */
+@10038  = ~Important Events
+
+Hephernaan has his own, dark plans. We witnessed him talking about serving the "Umbral Accord" - who or what is behind this name, I can only guess.~
 /*
-@10038  = 
 @10039  = 
 @10040  = 
 */

--- a/sodrtd/translations/french/dialogue.tra
+++ b/sodrtd/translations/french/dialogue.tra
@@ -72,6 +72,10 @@
 @69   = ~[Marshal Nederlok]Eh bien, nous nous attendions à une menace de cette ampleur. Merci pour la confirmation.~
 @70   = ~[PC reply]J'ai des nouvelles informations sur les plans de Caelar. Nous devons en discuter de toute urgence.~
 
+/* new in v1 */
+@71   = ~[Torsin De Lancie]Hmm, I never heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~
+@72   = ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~
+
 /* add_sir_deggernaut.d */
 @200  = ~[Sir Deggernaut (male)]Salutations, je suis le Seigneur Deggernaut. Les Ducs ont décidé de m'envoyer en renfort pour superviser la progression de nos forces et les tenir informés, ainsi que nos alliés, à tout moment. Je serai là si vous avez quelque chose à leur transmettre.~
 @201  = ~[Sir Deggernaut (male)]Y a-t-il quelque chose dont vous voulez nous faire part à propos de la croisade de Caelar ?~
@@ -173,6 +177,10 @@
 /* @292 also used in "include_reply_options.tph" */
 @292  = ~[PC Reply]J'ai vu quelque chose d'inquiétant qui me fait penser que Hephernaan, le conseiller de Caelar, est peut-être de mèche avec un démon.~
 
+/* new for v1 */
+@293  = ~[PC Reply]I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~
+@294  = ~[Sir Deggernaut (male)]Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far.~
+
 
 /* add_consistency_replyoptions.d */
 @500  = ~[PC Reply]Oui, je pense savoir ce qui s'est passé là-bas.~
@@ -212,6 +220,12 @@
 @1020 = ~[PC Selftalk](Vous remarquez la réaction de <PLAYER4> et n'avez pas besoin d'en savoir plus pour comprendre que cette « bénédiction » n'a rien d'extraordinaire. Et qu'elle n'octroie absolument aucunes des vertus « divines » promises par ce prêtre.)~
 @1021 = ~[PC Selftalk](Vous remarquez la réaction de <PLAYER5> et n'avez pas besoin d'en savoir plus pour comprendre que cette « bénédiction » n'a rien d'extraordinaire. Et qu'elle n'octroie absolument aucunes des vertus « divines » promises par ce prêtre.)~
 @1022 = ~[PC Selftalk](Vous remarquez la réaction de <PLAYER6> et n'avez pas besoin d'en savoir plus pour comprendre que cette « bénédiction » n'a rien d'extraordinaire. Et qu'elle n'octroie absolument aucunes des vertus « divines » promises par ce prêtre.)~
+
+/* new for v1 */
+@1023 = ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~
+@1024 = ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~
+@1025 = ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~
+@1026 = ~[PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~
 
 /* add_reactions.d */
 @1500 = ~[Captain Corwin]Et - nous savons tous ce qu'il adviendrait si la croisade vous mettait la main dessus. Je suppose que c'est une autre bonne raison d'assurer votre sécurité, <CHARNAME>.~

--- a/sodrtd/translations/french/dialogue.tra
+++ b/sodrtd/translations/french/dialogue.tra
@@ -73,8 +73,8 @@
 @70   = ~[PC reply]J'ai des nouvelles informations sur les plans de Caelar. Nous devons en discuter de toute urgence.~
 
 /* new in v1 */
-@71   = ~[Torsin De Lancie]Hmm, I never heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~
-@72   = ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~
+ @71 = ~[Torsin De Lancie]Humm, jamais entendu parler, mais il serait judicieux de contacter nos sages et nos supérieurs pour obtenir des renseignements à ce sujet. Si nous sommes confrontés à une organisation secrète, il est impératif d'en savoir plus et le plus tôt possible.~ 
+@72   = ~[Marshal Nederlok]Apprendre que notre ennemi est lié à une organisation secrète ne m'étonne pas le moins du monde. La vraie question est de connaître son implication dans la situation actuelle et le danger qu'elle représente. Nous devons rassembler autant d'informations que possible sur ce mystérieux « Accord de l'Ombre ».~
 
 /* add_sir_deggernaut.d */
 @200  = ~[Sir Deggernaut (male)]Salutations, je suis le Seigneur Deggernaut. Les Ducs ont décidé de m'envoyer en renfort pour superviser la progression de nos forces et les tenir informés, ainsi que nos alliés, à tout moment. Je serai là si vous avez quelque chose à leur transmettre.~
@@ -178,8 +178,8 @@
 @292  = ~[PC Reply]J'ai vu quelque chose d'inquiétant qui me fait penser que Hephernaan, le conseiller de Caelar, est peut-être de mèche avec un démon.~
 
 /* new for v1 */
-@293  = ~[PC Reply]I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~
-@294  = ~[Sir Deggernaut (male)]Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far.~
+@293 = ~[PC Reply]Je soupçonne Hephernaan d'avoir des ambitions personnelles bien plus obscures. Il est apparemment en relation avec « l'Accord de l'Ombre », une organisation qui pourrait bien s'avérer être un adversaire de taille.~ 
+@294  = ~[Sir Deggernaut (male)]Hephernaan est également en accointances avec une organisation mystérieuse dénommée « Accord de l'Ombre ». À ce jour, nous n'avons pas d'autres précisions sur l'origine de ce nom.~
 
 
 /* add_consistency_replyoptions.d */
@@ -222,10 +222,10 @@
 @1022 = ~[PC Selftalk](Vous remarquez la réaction de <PLAYER6> et n'avez pas besoin d'en savoir plus pour comprendre que cette « bénédiction » n'a rien d'extraordinaire. Et qu'elle n'octroie absolument aucunes des vertus « divines » promises par ce prêtre.)~
 
 /* new for v1 */
-@1023 = ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~
-@1024 = ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~
-@1025 = ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~
-@1026 = ~[PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~
+@1023 = ~[Daeros]Il s'agissait d'un être démoniaque, Hephernaan promettait d'ouvrir un portail pour lui permettre de revenir sur le Plan Primaire. Comme le sang de Caelar n'était pas une ressource suffisante, ils ont parlé de chercher la progéniture d'un autre dieu, un rejeton dont le sang serait moins « dilué ».~
+@1024 = ~[PC Reply]Un *démon*, attendant l'ouverture d'un portail. Cela éclaircit beaucoup de choses...~
+@1025 = ~[Daeros]Oui, en effet. Je suis étonné de ne pas avoir été éliminé ou banni après les avoir entendus. J'imagine qu'ils ne s'attendaient pas vraiment à ce que quelqu'un se balade par ici et pose des questions.~
+@1026 = ~[PC Reply]Hephernaan est de mèche avec une sombre entité. Avez-vous pu discerner sa nature ? De quoi ont-ils parlé ?~ 
 
 /* add_reactions.d */
 @1500 = ~[Captain Corwin]Et - nous savons tous ce qu'il adviendrait si la croisade vous mettait la main dessus. Je suppose que c'est une autre bonne raison d'assurer votre sécurité, <CHARNAME>.~

--- a/sodrtd/translations/french/game.tra
+++ b/sodrtd/translations/french/game.tra
@@ -115,8 +115,12 @@ J'ai assisté au rituel de « bénédiction » dans les camps de la croisade, av
 @10037  = ~Événements importants
 
 Qui l'eût cru. La grande et puissante Caelar fut renvoyée de son Ordre de paladins - à un très jeune âge. Son oncle Aun Argent, semble avoir disparu à la même période.~
+
+/* new in v1 */
+@10038  = ~Important Events
+
+Hephernaan has his own, dark plans. We witnessed him talking about serving the "Umbral Accord" - who or what is behind this name, I can only guess.~
 /*
-@10038  = 
 @10039  = 
 @10040  = 
 */

--- a/sodrtd/translations/french/game.tra
+++ b/sodrtd/translations/french/game.tra
@@ -117,9 +117,9 @@ J'ai assisté au rituel de « bénédiction » dans les camps de la croisade, av
 Qui l'eût cru. La grande et puissante Caelar fut renvoyée de son Ordre de paladins - à un très jeune âge. Son oncle Aun Argent, semble avoir disparu à la même période.~
 
 /* new in v1 */
-@10038  = ~Important Events
+ @10038  = ~Événements importants
 
-Hephernaan has his own, dark plans. We witnessed him talking about serving the "Umbral Accord" - who or what is behind this name, I can only guess.~
+Hephernaan a de sombres intentions. Nous avons assisté à une discussion mentionnant son allégeance à « l'Accord de l'Ombre »... la personne ou la chose qui se cache derrière ce nom, est pure spéculation.~ 
 /*
 @10039  = 
 @10040  = 

--- a/sodrtd/translations/german/dialogue.tra
+++ b/sodrtd/translations/german/dialogue.tra
@@ -74,6 +74,11 @@
 @68     = ~[Marshal Nederlok]Ja, ihre Anhänger bereiten sich sicherlich darauf vor. Wir wissen immer noch nicht, wie sie das überhaupt erreichen will. Lasst es uns wissen, sobald Ihr mehr Informationen dazu habt.~
 @69     = ~[Marshal Nederlok]Nun, das haben wir schon vermutet. Ich danke Euch für die Bestätigung.~
 @70     = ~[PC reply]Ich habe mehr Informationen über Caelars Pläne, die wir jetzt besprechen sollten.~
+
+/* new in v1 */
+@71   = ~[Torsin De Lancie]Hmm, den Namen habe ich noch nie gehört, aber es wäre klug, unsere Weisen und Berater um Informationen zu ersuchen. Wenn wir es mit einer geheimen Organisation zu tun haben, sollten wir so bald wie möglich wissen, gegen wen wir da antreten.~
+@72   = ~[Marshal Nederlok]Ich bin wenig überrascht, einen Namen von einer Geheimorganisation zu hören, die mit unseren Feinden in Verbindung steht. Die Frage ist, wie groß die Gefahr ist, die sie in der gegenwärtigen Situation für uns darstellen. Wir müssen so viele Informationen über diese "Schattenübereinkunft" sammeln wie möglich.~
+
 @200    = ~[Sir Deggernaut (male)]Seid gegrüßt, ich bin Sir Deggernaut. Die Herzöge haben beschlossen, mich mit Euch zu schicken, um die Fortschritte der Bündniskräfte zu überwachen und die Herzöge sowie unsere Verbündeten jederzeit umfassend zu informieren. Ich werde hier sein, wenn Ihr den Herzögen oder den anderen Bündnisoffizieren etwas mitteilen wollt.~
 @201    = ~[Sir Deggernaut (male)]Gibt es etwas, das Ihr uns über Caelars Kreuzzug mitteilen wollt?~
 @202    = ~[PC reply]Ich weiß etwas über die Pläne des Kreuzzuges, das die Offiziere wissen sollten.~
@@ -175,6 +180,10 @@
 
 @292  = ~[PC Reply]Ich wurde durch Zufall Zeuge einer Szene die den verstörenden Schluss zulässt, dass Ifearnan irgendwie mit einem Teufel im Bunde ist!~
 
+/* new for v1 */
+@293  = ~[PC Reply]Ich habe gewichtige Gründe zu glauben, dass Ifearnan eigene, unerfreuliche Pläne hat. Er scheint für eine Organisation namens "Schattenübereinkunft" zu arbeiten, und diese scheint mächtig zu sein.~
+@294  = ~[Sir Deggernaut (male)]Ifearnan ist auch mit einer geheimen Organisation namens Schattenübereinkunft in Verbindung. Wir haben bisher keine weiteren Informationen, wofür der Name steht.~
+
 @500    = ~[PC reply]Ja, ich glaube, ich weiß, was da passiert ist.~
 @501    = ~[PC rely]Ich werde Euch nicht helfen, ein Portal nach Avernus zu öffnen, Caelar. Das ist Wahnsinn.~
 @502    = ~[PC reply]Ich glaube, dass Caelars wahres Ziel darin besteht, ihren Onkel Aun zu befreien, der wegen ihr in Avernus gefangen war.~
@@ -210,6 +219,14 @@
 @1020   = ~[PC selftalk](Ihr habt die Reaktion von <PLAYER4> auf die Aufführung bemerkt und braucht keine weiteren Informationen, um zu wissen, dass dieser „Segen“ nichts Besonderes ist. Schon gar nicht ist er ein Schutz durch „die Götter“, wie der das Ritual durchführende Priester verkündet hatte.)~
 @1021   = ~[PC selftalk](Ihr habt die Reaktion von <PLAYER5> auf die Aufführung bemerkt und braucht keine weiteren Informationen, um zu wissen, dass dieser „Segen“ nichts Besonderes ist. Schon gar nicht ist er ein Schutz durch „die Götter“, wie der das Ritual durchführende Priester verkündet hatte.)~
 @1022   = ~[PC selftalk](Ihr habt die Reaktion von <PLAYER6> auf die Aufführung bemerkt und braucht keine weiteren Informationen, um zu wissen, dass dieser „Segen“ nichts Besonderes ist. Schon gar nicht ist er ein Schutz durch „die Götter“, wie der das Ritual durchführende Priester verkündet hatte.)~
+
+/* new for v1 */
+@1023 = ~[Daeros]Es war ein Teufel, und Ifearnan versprach, ein Portal zu öffnen, damit er zum Prime zurückkehren kann. Da Caelars Blut nicht ausreichet, sprachen sie darüber, nach einem anderen, weniger "verdünnten" Nachkommen eines Gottes zu suchen.~
+@1024 = ~[PC Reply]Ein *Teufel*, der darauf wartet, dass ein Portal geöffnet wird. Das erklärt eine Menge...~
+@1025 = ~[Daeros]Oja, das tut es. Ich bin überrascht, dass er mich nicht umgebracht oder verbannt hat, nachdem ich das gehört habe. Ich schätze, er hat nicht erwartet, dass hier jemand reinkommt und Fragen stellt.~
+@1026 = ~[PC Reply]Ifearnan sprach mit einem dunklen Wesen - konntet Ihr erkennen, was es genau war? Worüber haben sie gesprochen?~
+
+
 @1500   = ~[Captain Corwin]Und wir alle wissen, was passieren würde, wenn der Kreuzzug Euch in die Finger bekäme. Ich gebe zu, das ist ebenfalls eine starke Motivation, für Eure Sicherheit zu sorgen, <CHARNAME>.~
 @1501   = ~[Marshal Nederlok]Das Wissen um das Portal unter der Burg und Euer Blut, das man braucht, um es zu öffnen, hat uns in höchste Alarmbereitschaft versetzt, <CHARNAME>. Kommt bald zum Zelt der Kommandierenden!~
 @1502   = ~[Torsin De Lancie]Jetzt, da Ihr hier seid, müssen wir Caelar aufhalten – jetzt mehr denn je.~

--- a/sodrtd/translations/german/game.tra
+++ b/sodrtd/translations/german/game.tra
@@ -115,3 +115,8 @@ Ich war Zeuge des „Segnungsrituals“ in den Lagern der Kreuzzügler und hatte
 @10037  = ~Wichtige Ereignisse
 
 Wer hätte das gedacht? Die hochmütige Caelar ist in ihrem Paladinorden in Ungnade gefallen – und das als Kind. Auch einer ihrer Onkel ist zu dieser Zeit auf mysteriöse Weise verschwunden.~
+
+/* new in v1 */
+@10038  = ~Wichtige Ereignisse
+
+Ifearnan hat seine eigenen, dunklen Pläne. Wir wurden Zeuge, wie er davon sprach, einer "Schattenübereinkunft" zu dienen - wer order was dahinter steckt, kann ich nur vermuten.~

--- a/sodrtd/translations/italian/dialogue.tra
+++ b/sodrtd/translations/italian/dialogue.tra
@@ -72,6 +72,10 @@
 @69 = ~[Maresciallo Nederlok]Ci aspettavamo una minaccia di questa portata. Grazie per la conferma.~
 @70 = ~[Risposta del giocatore]Ho nuove informazioni sui piani di Caelar. Dobbiamo discuterne con urgenza.~
 
+/* new in v1 */
+@71   = ~[Torsin De Lancie]Hmm, I never heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~
+@72   = ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~
+
 /* add_sir_deggernaut.d */
 @200  = ~[Sir Deggernaut (maschio)]Salve, sono Sir Deggernaut. I Duchi hanno deciso di inviarmi come rinforzo per supervisionare i progressi delle nostre forze e tenere sempre informati loro e i nostri alleati. Sarò sempre presente se avrai qualcosa da comunicare.~
 @201  = ~[Sir Deggernaut (maschio)]C'è qualcosa che vuoi condividere con noi sulla crociata di Caelar?~
@@ -174,6 +178,10 @@
 /* @292 also used in "include_reply_options.tph" */
 @292  = ~[PC Reply]Ho visto qualcosa di inquietante che mi fa pensare che Hephernaan, il consigliere di Caelar, possa essere in qualche modo in combutta con un demone.~
 
+/* new for v1 */
+@293  = ~[PC Reply]I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~
+@294  = ~[Sir Deggernaut (male)]Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far.~
+
 /* add_consistency_replyoptions.d */
 @500 = ~[Risposta del giocatore]Sì, credo di sapere cosa sia successo lì.~
 @501 = ~[Risposta del giocatore]Non ti aiuterò ad aprire un portale per Avernus, Caelar. È una follia.~
@@ -212,6 +220,12 @@
 @1020 = ~[Frasi automatiche](Hai notato la reazione di <PLAYER4> al rituale e non ti servono altre informazioni per sapere che questa benedizione non è affatto speciale, e sicuramente non è una protezione concessa degli Dèi, come proclamato dal sacerdote officiante).~
 @1021 = ~[Frasi automatiche](Hai notato la reazione di <PLAYER5> al rituale e non ti servono altre informazioni per sapere che questa benedizione non è affatto speciale, e sicuramente non è una protezione concessa degli Dèi, come proclamato dal sacerdote officiante).~
 @1022 = ~[Frasi automatiche](Hai notato la reazione di <PLAYER6> al rituale e non ti servono altre informazioni per sapere che questa benedizione non è affatto speciale, e sicuramente non è una protezione concessa degli Dèi, come proclamato dal sacerdote officiante).~
+
+/* new for v1 */
+@1023 = ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~
+@1024 = ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~
+@1025 = ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~
+@1026 = ~[PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~
 
 /* add_reactions.d */
 @1500 = ~[Capitano Corwin]E... sappiamo tutti cosa accadrebbe se la crociata mettesse le mani su di te. Ammetto che questa è una forte motivazione per garantire anche la tua sicurezza, <CHARNAME>.~

--- a/sodrtd/translations/italian/dialogue.tra
+++ b/sodrtd/translations/italian/dialogue.tra
@@ -73,8 +73,8 @@
 @70 = ~[Risposta del giocatore]Ho nuove informazioni sui piani di Caelar. Dobbiamo discuterne con urgenza.~
 
 /* new in v1 */
-@71   = ~[Torsin De Lancie]Hmm, I never heard that name, but it will be wise to contact our sages and advisors for information. If we are up against a secret organisation, we should know about what we will have to face as soon as possible.~
-@72   = ~[Marshal Nederlok]I am less surprised to hear a name from a secret organisation connected to our foes. The question is how much danger they pose to us in teh current situation. We need to gather as many information about this "Umbral Accord" as possible.~
+@71   = ~[Torsin De Lancie]Hmm, questo nome mi è nuovo, ma sarà opportuno contattare i nostri saggi e i nostri consiglieri per chiedere informazioni. Se abbiamo contro un'organizzazione segreta, dobbiamo sapere il prima possibile ciò che saremo chiamati ad affrontare.~
+@72   = ~[Maresciallo Nederlok]Non mi sorprende che salti fuori il nome di un'organizzazione segreta tra legami dei nostri avversari. La vera domanda è che pericolo rappresenti per noi nella nostra attuale situazione. Dobbiamo raccogliere quante più informazioni possibili su questa "Fosca Alleanza".~
 
 /* add_sir_deggernaut.d */
 @200  = ~[Sir Deggernaut (maschio)]Salve, sono Sir Deggernaut. I Duchi hanno deciso di inviarmi come rinforzo per supervisionare i progressi delle nostre forze e tenere sempre informati loro e i nostri alleati. Sarò sempre presente se avrai qualcosa da comunicare.~
@@ -179,8 +179,8 @@
 @292  = ~[PC Reply]Ho visto qualcosa di inquietante che mi fa pensare che Hephernaan, il consigliere di Caelar, possa essere in qualche modo in combutta con un demone.~
 
 /* new for v1 */
-@293  = ~[PC Reply]I have reasons to believe that Hephernaan has own, darker plans. He seems in liege with some organisation called "Umbral Accord", and they seem to be powerful.~
-@294  = ~[Sir Deggernaut (male)]Hephernaan is also in liege with a secret organization called Umbral Accord. We do not have any further information what the name stands for so far.~
+@293  = ~[Risposta del giocatore]Ho ragione di credere che Hephernaan abbia i propri, oscuri piani. Sembra che sia al servizio di una qualche organizzazione chiamata "Fosca Alleanza", e pare che questa sia molto potente.~
+@294  = ~[Sir Deggernaut (maschio)]Hephernaan è anche al servizio di un'organizzazione segreta chiamata Fosca Alleanza. Per ora non abbiamo ulteriori informazioni su chi e cosa ci sia dietro questo nome.~
 
 /* add_consistency_replyoptions.d */
 @500 = ~[Risposta del giocatore]Sì, credo di sapere cosa sia successo lì.~
@@ -222,10 +222,10 @@
 @1022 = ~[Frasi automatiche](Hai notato la reazione di <PLAYER6> al rituale e non ti servono altre informazioni per sapere che questa benedizione non è affatto speciale, e sicuramente non è una protezione concessa degli Dèi, come proclamato dal sacerdote officiante).~
 
 /* new for v1 */
-@1023 = ~[Daeros]It was a fiend, and Hephernaan was promising to open a portal so it could return to the Prime. Since Caelar's blood wouldn't suffice, they talked about looking for another, less "diluted" offspring of a god.~
-@1024 = ~[PC Reply]A *fiend*, waiting for a portal to be opened. This explains a lot...~
-@1025 = ~[Daeros]Aye, it does. I'm surprised he didn't kill or banished me after I heard that. I guess he didn't expect anyone walking in here, asking questions.~
-@1026 = ~[PC Reply]Hephernaan spoke with a dark creature - could you see what it was, exactly? What did they discuss?~
+@1023 = ~[Daeros]Era un demone, ed Hephernaan gli stava promettendo che avrebbe aperto un portale in modo che potesse tornare al Primo Piano Materiale. Dato che il sangue di Caelar non sarebbe stato sufficiente, discutevano di cercare un'altra progenie divina dal sangue meno "diluito".~
+@1024 = ~[PC Reply]Un *demone*, in attesa che venisse aperto un portale. Questo spiega molte cose...~
+@1025 = ~[Daeros]Già. Sono sorpreso che non mi abbia ucciso o esiliato dopo quello che ho ascoltato. Immagino non si aspettasse che qualcuno entrasse qui, a fare domande.~
+@1026 = ~[PC Reply]Hephernaan ha parlato con una creatura oscura - sei riuscito a vedere di preciso cosa fosse? Di cosa hanno discusso?~
 
 /* add_reactions.d */
 @1500 = ~[Capitano Corwin]E... sappiamo tutti cosa accadrebbe se la crociata mettesse le mani su di te. Ammetto che questa è una forte motivazione per garantire anche la tua sicurezza, <CHARNAME>.~

--- a/sodrtd/translations/italian/game.tra
+++ b/sodrtd/translations/italian/game.tra
@@ -113,8 +113,8 @@ Sono stato testimone del rituale della benedizione nell'accampamento dei crociat
 @10037 = ~Eventi importanti
 
 Chi l'avrebbe mai detto. La grande e potente Caelar è stata disonorata dal suo Ordine di paladini, per giunta da bambina. Anche uno dei suoi zii è scomparso misteriosamente in quel periodo.~
-/*
-@10038  = 
-@10039  = 
-@10040  = 
-*/
+
+/* new in v1 */
+@10038  = ~Important Events
+
+Hephernaan has his own, dark plans. We witnessed him talking about serving the "Umbral Accord" - who or what is behind this name, I can only guess.~

--- a/sodrtd/translations/italian/game.tra
+++ b/sodrtd/translations/italian/game.tra
@@ -115,6 +115,6 @@ Sono stato testimone del rituale della benedizione nell'accampamento dei crociat
 Chi l'avrebbe mai detto. La grande e potente Caelar è stata disonorata dal suo Ordine di paladini, per giunta da bambina. Anche uno dei suoi zii è scomparso misteriosamente in quel periodo.~
 
 /* new in v1 */
-@10038  = ~Important Events
+@10038 = ~Eventi Importanti
 
-Hephernaan has his own, dark plans. We witnessed him talking about serving the "Umbral Accord" - who or what is behind this name, I can only guess.~
+Hephernaan ha i propri, oscuri piani. Lo abbiamo visto di persona dire di essere al servizio della "Fosca Alleanza" - chi o cosa si celi dietro tale nome, posso solo immaginarlo.~


### PR DESCRIPTION
- Scrypool Scene with Hephernaan will no longer lead to hints about fiend master. PC can tell officers about "Umbral Accord" instead.
- Scrypool Scene will no longer lead to conclusion that Hephrnaan is betraying Caelar.
- Sir Deggernaut will have appropriate scripts in camps.
- Added extra reply option to Daeros dialogue to learn about fiend master. Hearing about "dark creature in mirror" will no longer lead to this knowledge directly.
- Variable "C#RtD_HephernaanVisual" has value of 2: "PC knows that Hephernaan [who is Caelar's advisor] is working with Umbral Accord"; added "C#RtD_CoalHephernaanVisual" accordingly; updated readme and docs with description.
- Updated links in sodrtd.ini.